### PR TITLE
Bug fix for #25 (Allows multiple delegate preparation)

### DIFF
--- a/tensorflow/lite/core/subgraph.cc
+++ b/tensorflow/lite/core/subgraph.cc
@@ -392,6 +392,13 @@ TfLiteStatus Subgraph::ReplaceNodeSubsetsWithDelegateKernels(
         // Initialize the output tensors's delegate-related fields.
         for (int tensor_index : node_subset.output_tensors) {
           TfLiteTensor* tensor = &tensors_[tensor_index];
+          if(tensor->delegate != nullptr && tensor->delegate != delegate) {
+            // TODO #13 : Print name of the delegate 
+            // Expected output : Overwriting delegate from %s to %s.
+            TFLITE_LOG(
+              tflite::TFLITE_LOG_WARNING,
+              "Overwriting delegate.");
+          }
           tensor->delegate = delegate;
         }
 


### PR DESCRIPTION
This is a proposed fix for #25 

Decided to choose option 1 of #25 
It's mainly because of the following reasons.
1.  `ReplaceNodeSubsetsWithDelegateKernels` (function that contains the ensure check) is what all `Delegate` classes are used to update `delegate` member of tensors. So we don't need to check nullity or equality before overriding.
2.  Confirmed that this fix doesn't break the system while working on #10, #13
3.  Reinitializing `delegate` member of tensors can be a general solution that can preserve the existing code. However, it can be a temporal fix after addressing #16 since we don't need to `Undo` or `Remove` delegates after #16.