### PR TITLE
Add qti-hta as a NPU (#23)

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -4183,7 +4183,7 @@ TfLiteDelegateFlags GetNNAPIDeviceFlag(std::string name) {
     return kTfLiteDelegateFlagsNNAPIDSP;
   }
 
-  if (contains_keywords({ "google-edgetpu", "armnn", "neuron-ann" })) {
+  if (contains_keywords({ "google-edgetpu", "armnn", "neuron-ann", "qti-hta" })) {
     return kTfLiteDelegateFlagsNNAPINPU;
   }
 


### PR DESCRIPTION
I tested `qti-hta` on Samsung Galaxy S20 and it can compute alongside with a DSP delegate.
