### PR TITLE
Hotfix for memory leak during profiling

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -587,9 +587,9 @@ TfLiteStatus Interpreter::GetBufferHandle(int tensor_index,
 void Interpreter::Profile(const int num_warm_ups, const int num_runs) {
   tflite::Profiler* previous_profiler = GetProfiler();
   // Assign temporal time profiler for profiling.
-  tflite::profiling::TimeProfiler* timer = new tflite::profiling::TimeProfiler;
+  tflite::profiling::TimeProfiler timer;
   // Only update subgraph profilers to not care ownership of the profiler
-  SetSubgraphProfiler(timer);
+  SetSubgraphProfiler(&timer);
 
   for (const int model_id : models()) {
     for (int device_id = 0; device_id < kTfLiteNumDevices; device_id++) {
@@ -601,13 +601,13 @@ void Interpreter::Profile(const int num_warm_ups, const int num_runs) {
         for (int i = 0; i < num_warm_ups; i++) {
           subgraph->Invoke();
         }
-        timer->ClearRecords();
+        timer.ClearRecords();
         for (int i = 0; i < num_runs; i++) {
           subgraph->Invoke();
         }
 
         subgraph_profiling_results_map_[{model_id, device_flag}] = 
-          timer->GetAverageElapsedTime<std::chrono::microseconds>();
+          timer.GetAverageElapsedTime<std::chrono::microseconds>();
 
         error_reporter_->Report("Profiling result\n model=%d warmup=%d count=%d avg=%d us device=%s.", 
                 model_id,


### PR DESCRIPTION
I've noticed that there is a potential memory leak in `Interpreter::Profile(const int num_warm_ups, const int num_runs)`.
We're dynamically allocating a `TimeProfiler` instance for profiling, but we're never actually releasing it.
By the time we reach the end of the function, we no longer need the `TimeProfiler` instance, so a simple fix to the memory leak would be to make the instance a local variable on the stack.

Tested with:
`./benchmark_model --json_path=model_config.json`
```shell
$ cat model_config.json
{
  "period_ms": 100,
  "cpu_masks": 0,
  "models": [
    {"graph": "/data/local/tmp/inception_v3_quant.tflite", "batch_size": 1},
    {"graph": "/data/local/tmp/mobilenet_v1_1.0_224_quant.tflite", "batch_size": 2}
  ]
}
```