### PR TITLE
Fix profile file save error

### DIFF
--- a/tensorflow/lite/util.cc
+++ b/tensorflow/lite/util.cc
@@ -73,11 +73,11 @@ Json::Value LoadJsonObjectFromFile(std::string file_path) {
 
 void WriteJsonObjectToFile(const Json::Value& json_object,
                            std::string file_path) {
-  if (FileExists(file_path)) {
-    std::ofstream out_file(file_path, std::ios::out);
+  std::ofstream out_file(file_path, std::ios::out);
+  if (out_file.is_open()) {
     out_file << json_object;
   } else {
-    TFLITE_LOG(WARN) << "There is no such file: " << file_path;
+    TFLITE_LOG(ERROR) << "Cannot save profiled results to " << file_path;
   }
 }
 


### PR DESCRIPTION
Current Behavior
* Not creating new profile json file.

Changed Behavior
* Overwrite profile json file with updated profiled time map.

@jsjason @dostos @chang-jin @kdh0102
Simple bug fix, so it would be nice to merge it right after review.