### PR TITLE
CPU Frequency functions / Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ $ adb shell /data/local/tmp/benchmark_model --json_path=$PATH_TO_CONFIG_FILE [OP
   * `input_layer_value_files`: A map-like string representing value file. Each item is separated by ',', and the item value consists of input layer name and value file path separated by ':', e.g. input1:file_path1,input2:file_path2. If the input_name appears both in input_layer_value_range and input_layer_value_files, input_layer_value_range of the input_name will be ignored. The file format is binary and it should be array format or null separated strings format.
   * `slo_us` and `slo_scale`: **Optional** fields for specifying an SLO value for a model. Setting `slo_scale` will make the SLO = worst profiled latency of that model * `slo_scale`. `slo_scale` will be ignored if `slo_us` is given (i.e., no reason to specify both options).
 * `log_path`: The log file path. (e.g., `/data/local/tmp/model_execution_log.csv`)
+* `log_processor_frequency`: Whether planner log processor frequencies to log file. [default: true]
 * `schedulers`: The scheduler types in `list[int]`. If N schedulers are specified, then N queues are generated.
   * `0`: Fixed Device Planner
   * `1`: Round-Robin Planner
@@ -123,6 +124,7 @@ An example of complete JSON config file is as follows:
         }
     ],
     "log_path": "/data/local/tmp/log.csv",
+    "log_processor_frequency": false,
     "schedulers": [0, 2],
     "minimum_subgraph_size": 7,
     "subgraph_preparation_type": "merge_unit_subgraph",

--- a/tensorflow/lite/config.cc
+++ b/tensorflow/lite/config.cc
@@ -112,6 +112,11 @@ TfLiteStatus ParseRuntimeConfigFromJson(std::string json_fname,
   } else {
     planner_config.cpu_masks = interpreter_config.cpu_masks;
   }
+  // 5. Log processor frequency
+  if (!root["log_processor_frequency"].isNull()) {
+    planner_config.log_processor_frequency =
+        root["log_processor_frequency"].asBool();
+  }
 
   std::vector<bool> found_default_worker(kTfLiteNumDevices, false);
   // Set Worker configs

--- a/tensorflow/lite/config.h
+++ b/tensorflow/lite/config.h
@@ -41,6 +41,7 @@ struct InterpreterConfig {
 
 struct PlannerConfig {
   std::string log_path;
+  bool log_processor_frequency = true;
   int schedule_window_size = INT_MAX;
   std::vector<TfLiteSchedulerType> schedulers;
   impl::TfLiteCPUMaskFlags cpu_masks = impl::kTfLiteAll;

--- a/tensorflow/lite/cpu.cc
+++ b/tensorflow/lite/cpu.cc
@@ -102,6 +102,265 @@ int GetLittleCPUCount() { return TfLiteCPUMaskGetSet(kTfLiteLittle).NumEnabled()
 
 int GetBigCPUCount() { return TfLiteCPUMaskGetSet(kTfLiteBig).NumEnabled(); }
 
+int GetCPUScalingMaxFrequencyKhz(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from cpu id
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_max_freq", cpu);
+  FILE* fp = fopen(path, "rb");
+
+  // second try from policy
+  if (!fp) {
+    sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/scaling_max_freq",
+            cpu);
+    fp = fopen(path, "rb");
+  }
+
+  if (fp) {
+    int freq_khz = 0;
+    fscanf(fp, "%d", &freq_khz);
+    fclose(fp);
+    return freq_khz;
+  } else {
+    return -1;
+  }
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUScalingMaxFrequencyKhz(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_frequency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_frequency += GetCPUScalingMaxFrequencyKhz(i);
+  }
+
+  return accumulated_frequency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUScalingMinFrequencyKhz(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from cpu id
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_min_freq", cpu);
+  FILE* fp = fopen(path, "rb");
+
+  // second try from policy
+  if (!fp) {
+    sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/scaling_min_freq",
+            cpu);
+    fp = fopen(path, "rb");
+  }
+
+  if (fp) {
+    int freq_khz = 0;
+    fscanf(fp, "%d", &freq_khz);
+    fclose(fp);
+    return freq_khz;
+  } else {
+    return -1;
+  }
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUScalingMinFrequencyKhz(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_frequency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_frequency += GetCPUScalingMinFrequencyKhz(i);
+  }
+
+  return accumulated_frequency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUScalingFrequencyKhz(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from cpu id
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu);
+  FILE* fp = fopen(path, "rb");
+
+  // second try from policy
+  if (!fp) {
+    sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/scaling_cur_freq",
+            cpu);
+    fp = fopen(path, "rb");
+  }
+
+  if (fp) {
+    int freq_khz = 0;
+    fscanf(fp, "%d", &freq_khz);
+    fclose(fp);
+    return freq_khz;
+  } else {
+    return -1;
+  }
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUScalingFrequencyKhz(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_frequency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_frequency += GetCPUScalingFrequencyKhz(i);
+  }
+
+  return accumulated_frequency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUFrequencyKhz(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from cpu id
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_cur_freq", cpu);
+  FILE* fp = fopen(path, "rb");
+
+  // second try from policy
+  if (!fp) {
+    sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/cpuinfo_cur_freq",
+            cpu);
+    fp = fopen(path, "rb");
+  }
+
+  if (fp) {
+    int freq_khz = 0;
+    fscanf(fp, "%d", &freq_khz);
+    fclose(fp);
+    return freq_khz;
+  } else {
+    return -1;
+  }
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUFrequencyKhz(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_frequency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_frequency += GetCPUFrequencyKhz(i);
+  }
+
+  return accumulated_frequency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUUpTransitionLatencyMs(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from transition latency
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_transition_latency", cpu);
+  FILE* fp = fopen(path, "rb");
+  
+  if (fp) {
+    int latency_ns = 0;
+    fscanf(fp, "%d", &latency_ns);
+    fclose(fp);
+    if (latency_ns != 0) {
+      // nanoseconds to milliseconds
+      return latency_ns / 1000000;
+    }
+  }
+
+  // second try from schedutil policy
+  sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/schedutil/up_rate_limit_us",
+          cpu);
+  fp = fopen(path, "rb");
+
+  if (fp) {
+    int latency_us = 0;
+    fscanf(fp, "%d", &latency_us);
+    fclose(fp);
+    // microseconds to milliseconds
+    return latency_us / 1000;
+  }
+
+#endif
+  return -1;
+}
+int GetCPUUpTransitionLatencyMs(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_latency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_latency += GetCPUUpTransitionLatencyMs(i);
+  }
+
+  return accumulated_latency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
+int GetCPUDownTransitionLatencyMs(int cpu) {
+#if defined __ANDROID__ || defined __linux__
+  char path[256];
+  // first try from transition latency
+  sprintf(path, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_transition_latency", cpu);
+  FILE* fp = fopen(path, "rb");
+  
+  if (fp) {
+    int latency_ns = 0;
+    fscanf(fp, "%d", &latency_ns);
+    fclose(fp);
+    if (latency_ns != 0) {
+      // nanoseconds to milliseconds
+      return latency_ns / 1000000;
+    }
+  }
+
+  // second try from schedutil policy
+  sprintf(path, "/sys/devices/system/cpu/cpufreq/policy%d/schedutil/down_rate_limit_us",
+          cpu);
+  fp = fopen(path, "rb");
+
+  if (fp) {
+    int latency_us = 0;
+    fscanf(fp, "%d", &latency_us);
+    fclose(fp);
+    // microseconds to milliseconds
+    return latency_us / 1000;
+  }
+
+#endif
+  return -1;
+}
+
+int GetCPUDownTransitionLatencyMs(const CpuSet& cpu_set) {
+#if defined __ANDROID__ || defined __linux__
+  int accumulated_latency = 0;
+
+  for (int i = 0; i < GetCPUCount(); i++) {
+    if (cpu_set.IsEnabled(i)) accumulated_latency += GetCPUDownTransitionLatencyMs(i);
+  }
+
+  return accumulated_latency / cpu_set.NumEnabled();
+#elif
+  return -1;
+#endif
+}
+
 #if defined __ANDROID__ || defined __linux__
 static int get_max_freq_khz(int cpuid) {
   // first try, for all possible cpu

--- a/tensorflow/lite/cpu.h
+++ b/tensorflow/lite/cpu.h
@@ -56,6 +56,30 @@ int GetCPUCount();
 int GetLittleCPUCount();
 int GetBigCPUCount();
 
+// Get scaling frequency (current target frequency of the governor)
+int GetCPUScalingFrequencyKhz(int cpu);
+int GetCPUScalingFrequencyKhz(const CpuSet &cpu_set);
+
+// Get scaling max frequency (current target frequency of the governor)
+int GetCPUScalingMaxFrequencyKhz(int cpu);
+int GetCPUScalingMaxFrequencyKhz(const CpuSet &cpu_set);
+
+// Get scaling min frequency (current target frequency of the governor)
+int GetCPUScalingMinFrequencyKhz(int cpu);
+int GetCPUScalingMinFrequencyKhz(const CpuSet &cpu_set);
+
+// Get current frequency (requires sudo)
+int GetCPUFrequencyKhz(int cpu);
+int GetCPUFrequencyKhz(const CpuSet &cpu_set);
+
+// Time interval limit of frequency rise
+int GetCPUUpTransitionLatencyMs(int cpu);
+int GetCPUUpTransitionLatencyMs(const CpuSet& cpu_set);
+
+// Time interval limit of frequency down
+int GetCPUDownTransitionLatencyMs(int cpu);
+int GetCPUDownTransitionLatencyMs(const CpuSet& cpu_set);
+
 // set explicit thread affinity
 TfLiteStatus SetCPUThreadAffinity(const CpuSet& thread_affinity_mask);
 TfLiteStatus GetCPUThreadAffinity(CpuSet& thread_affinity_mask);

--- a/tensorflow/lite/planner/planner.h
+++ b/tensorflow/lite/planner/planner.h
@@ -62,6 +62,8 @@ class Planner {
 
   void SetWindowSize(int schedule_window_size);
 
+  bool GetLogProcessorFrequency() const { return log_processor_frequency_; }
+
   const std::map<int, int>& GetModelExecutionCounts() const {
     return model_execution_count_;
   }
@@ -84,6 +86,8 @@ class Planner {
   // Copy the Job instances from the `requests_` to the local queue.
   // Note that this function is to minimize the hold time for the queue lock.
   void CopyToLocalQueue(JobQueue& local_jobs);
+  void UpdateJobEnqueueStatus(Job& job, SubgraphKey& target) const;
+  void UpdateJobWorkerStatus(Job& job, Worker* worker) const;
 
   // Enqueue the request to the worker.
   void EnqueueToWorkers(ScheduleAction& action);
@@ -144,6 +148,7 @@ class Planner {
 
   std::condition_variable end_invoke_;
   std::string log_path_;
+  bool log_processor_frequency_;
 
   int schedule_window_size_ = INT_MAX;
 

--- a/tensorflow/lite/util.h
+++ b/tensorflow/lite/util.h
@@ -117,6 +117,17 @@ struct Job {
   int worker_id = -1;
   int device_id = -1;
   int start_unit_idx = 0;
+  
+  int64_t start_frequency = 0;
+  int64_t start_scaling_frequency = 0;
+  int64_t start_scaling_min_frequency = 0;
+  int64_t start_scaling_max_frequency = 0;
+
+  int64_t end_frequency = 0;
+  int64_t end_scaling_frequency = 0;
+  int64_t end_scaling_min_frequency = 0;
+  int64_t end_scaling_max_frequency = 0;
+
   std::vector<Job> following_jobs;
   // see Interpreter::MakeSubgraphsForFallbackOps for details on this field
   std::set<int> resolved_tensors;

--- a/tensorflow/lite/worker.h
+++ b/tensorflow/lite/worker.h
@@ -28,12 +28,14 @@ class Worker {
   TfLiteDeviceFlags GetDeviceFlag() const { return device_flag_; }
   int GetWorkerId() const { return worker_id_; }
   std::mutex& GetDeviceMtx() { return device_mtx_; }
+  std::mutex& GetCpuSetMtx() { return cpu_mtx_; }
   std::condition_variable& GetRequestCv() { return request_cv_; }
   TfLiteStatus UpdateWorkerThread(const CpuSet thread_affinity_mask, int num_threads);
   void WaitUntilDeviceAvailable(Subgraph& subgraph);
   bool IsAvailable();
   const CpuSet& GetWorkerThreadAffinity() const;
   int GetNumThreads() const;
+  TfLiteStatus SetWorkerThreadAffinity(const CpuSet thread_affinity_mask);
   virtual int64_t GetWaitingTime() = 0;
   // Make sure the worker lock is acquired before calling the function.
   // Currently, `Planner::Plan()` is the only user of the method, and `Plan()` calls `GiveJob`

--- a/tensorflow/lite/worker_device_queue.cc
+++ b/tensorflow/lite/worker_device_queue.cc
@@ -107,8 +107,15 @@ void DeviceQueueWorker::Work() {
               (job.end_time - job.invoke_time));
           if (job.following_jobs.size() != 0) {
             planner_ptr->EnqueueBatch(job.following_jobs);
-          } 
+          }
           TryCopyOutputTensors(job);
+          if (planner_ptr->GetLogProcessorFrequency()) {
+            std::lock_guard<std::mutex> cpu_lock(cpu_mtx_);
+            job.end_frequency = GetCPUFrequencyKhz(cpu_set_);
+            job.end_scaling_frequency = GetCPUScalingFrequencyKhz(cpu_set_);
+            job.end_scaling_min_frequency = GetCPUScalingMinFrequencyKhz(cpu_set_);
+            job.end_scaling_max_frequency = GetCPUScalingMaxFrequencyKhz(cpu_set_);
+          }
           job.status = kTfLiteJobSuccess;
 
         } else if (status == kTfLiteDelegateError) {

--- a/tensorflow/lite/worker_global_queue.cc
+++ b/tensorflow/lite/worker_global_queue.cc
@@ -131,8 +131,15 @@ void GlobalQueueWorker::Work() {
               (current_job_.end_time - current_job_.invoke_time));
           if (current_job_.following_jobs.size() != 0) {
             planner_ptr->EnqueueBatch(current_job_.following_jobs);
-          } 
+          }
           TryCopyOutputTensors(current_job_);
+          if (planner_ptr->GetLogProcessorFrequency()) {
+            std::lock_guard<std::mutex> cpu_lock(cpu_mtx_);
+            current_job_.end_frequency = GetCPUFrequencyKhz(cpu_set_);
+            current_job_.end_scaling_frequency = GetCPUScalingFrequencyKhz(cpu_set_);
+            current_job_.end_scaling_min_frequency = GetCPUScalingMinFrequencyKhz(cpu_set_);
+            current_job_.end_scaling_max_frequency = GetCPUScalingMaxFrequencyKhz(cpu_set_);
+          }
           current_job_.status = kTfLiteJobSuccess;
 
         } else if (status == kTfLiteDelegateError) {


### PR DESCRIPTION
## Changes

- Additional helper functions in `cpu` module
  - Get current/min/max scaling frequency
  - Get current frequency (requires root)
  - Get frequency update interval (`schedutil` governor uses different period for up/down transition)
- Log start/end frequency information for later latency prediction modeling

## Result from execution log
```
sched_id	model_name	model_id	device_id	start_idx	end_idx	subgraph_idx	enqueue_time	invoke_time	end_time	profiled_latency	expected_latency	start_frequency	start_scaling_frequency	start_scaling_min_frequency	start_scaling_max_frequency	end_frequency	end_scaling_frequency	end_scaling_min_frequency	end_scaling_max_frequency	slo_us	job status	is_final_subgraph
7	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155257259	1627141155258955	380	380	-1	1665600	1677600	1898400	-1	2155200	2155200	2155200	-1	1	0
0	/data/local/tmp/models/ICN_quant.tflite	3	3	0	9	31	1627141155254226	1627141155254540	1627141155260828	657	657	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
1	/data/local/tmp/models/ICN_quant.tflite	3	2	0	9	24	1627141155254226	1627141155254848	1627141155258573	901	901	-1	1665600	1665600	1665600	-1	2155200	2155200	2155200	-1	1	0
8	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155260948	1627141155262158	380	380	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
2	/data/local/tmp/models/ICN_quant.tflite	3	3	0	9	31	1627141155254226	1627141155262246	1627141155264207	657	657	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
9	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155265108	1627141155266848	380	380	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
6	/data/local/tmp/models/arc_mbv2_quant.tflite	1	1	0	70	7	1627141155254336	1627141155256850	1627141155270297	7583	7583	-1	1665600	1665600	1665600	-1	2155200	2155200	2155200	-1	1	1
10	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155268167	1627141155269929	380	380	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
4	/data/local/tmp/models/arc_mbv2_quant.tflite	1	2	0	70	8	1627141155254336	1627141155262318	1627141155271203	4873	4873	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	1
11	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155272425	1627141155273647	380	380	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
5	/data/local/tmp/models/arc_mbv2_quant.tflite	1	0	0	70	6	1627141155254336	1627141155254582	1627141155274479	6533	6533	-1	1665600	1665600	1665600	-1	2155200	2155200	2155200	-1	1	1
12	/data/local/tmp/models/efficientnet_lite0_int8_2.tflite	0	4	0	0	2	1627141155255051	1627141155274778	1627141155276074	380	380	-1	2155200	2155200	2155200	-1	2155200	2155200	2155200	-1	1	0
13		3	4	10	10	16	1627141155254226	1627141155277295	1627141155279541	378	378	-1	2155200	2155200	2155200	-1	1929600	1929600	1929600	0	1	0
3	/data/local/tmp/models/arc_res50_quant.tflite	2	3	0	75	13	1627141155254360	1627141155265720	1627141155278672	6216	6216	-1	2155200	2155200	2155200	-1	1929600	1939200	1968000	-1	1	1
15		3	4	10	10	16	1627141155254226	1627141155281220	1627141155283024	378	378	-1	1968000	1968000	1968000	-1	1968000	1968000	1968000	0	1	0
17		3	4	10	10	16	1627141155254226	1627141155284612	1627141155286463	378	378	-1	1744800	1744800	1838400	-1	1838400	1838400	1838400	0	1	0
25		0	4	63	63	4	1627141155255051	1627141155288050	1627141155289762	3	3	-1	1838400	1838400	1838400	-1	1838400	1838400	1838400	0	1	1
```