### PR TITLE
[Minor Bug Fix] Add `profile_warmup_runs` and `profile_num_runs` to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ $ adb shell /data/local/tmp/benchmark_model --json_path=$PATH_TO_CONFIG_FILE [OP
 * `running_time_ms`: Experiment duration in ms. [default: 60000]
 * `profile_smoothing_factor`: Current profile reflection ratio. `updated_profile = profile_smoothing_factor * curr_profile + (1 - profile_smoothing_factor) * prev_profile` [default: 0.1]
 * `model_profile`: The path to file with model profile results. [default: None]
+* `profile_warmup_runs`: Number of warmup runs before profile. [default: 3]
+* `profile_num_runs`: Number of runs for profile. [default: 50]
 * `allow_work_steal`: True if work-stealing is allowed. The argument is only effective with `ShortestExpectedLatencyPlanner`.
 * `schedule_window_size`: The number of planning unit.
 * `global_period_ms`: Request interval value used for execution mode `periodic_single_thread` only. Should be > 0.
@@ -119,6 +121,8 @@ An example of complete JSON config file is as follows:
     "running_time_ms": 60000,
     "profile_smoothing_factor": 0.1,
     "model_profile": "/data/local/tmp/profile.json",
+    "profile_warmup_runs": 10,
+    "profile_num_runs": 20,
     "allow_work_steal": true,
     "schedule_window_size": 10
 }
@@ -126,7 +130,3 @@ An example of complete JSON config file is as follows:
 
 ### OPTIONS
 Refer to [Benchmark Tool](tensorflow/lite/tools/benchmark) for details.
-
-The following options are added in our version:
-* `profile_warmup_runs`: The number of warmup runs during profile stage.
-* `profile_num_runs`: The number of iterations during profile stage.

--- a/tensorflow/lite/config.cc
+++ b/tensorflow/lite/config.cc
@@ -65,6 +65,13 @@ TfLiteStatus ParseRuntimeConfigFromJson(std::string json_fname,
   if (!root["model_profile"].isNull()) {
     interpreter_config.profile_data_path = root["model_profile"].asString();
   }
+  // 4. Profile config
+  if (!root["profile_warmup_runs"].isNull()) {
+    interpreter_config.profile_config.num_warmups = root["profile_warmup_runs"].asInt();
+  }
+  if (!root["profile_num_runs"].isNull()) {
+    interpreter_config.profile_config.num_runs = root["profile_num_runs"].asInt();
+  }
 
   // Set Planner configs
   // 1. Log path

--- a/tensorflow/lite/tools/benchmark/benchmark_model.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_model.cc
@@ -43,8 +43,6 @@ BenchmarkParams BenchmarkModel::DefaultParams() {
   // setting this to zero because the periodic benchmark takes long
   params.AddParam("warmup_runs", BenchmarkParam::Create<int32_t>(0));
   params.AddParam("warmup_min_secs", BenchmarkParam::Create<float>(0.0f));
-  params.AddParam("profile_num_runs", BenchmarkParam::Create<int32_t>(50));
-  params.AddParam("profile_warmup_runs", BenchmarkParam::Create<int32_t>(1));
   params.AddParam("json_path", BenchmarkParam::Create<std::string>(""));
   return params;
 }
@@ -107,12 +105,6 @@ std::vector<Flag> BenchmarkModel::GetFlags() {
           "warmup_min_secs", &params_,
           "minimum number of seconds to rerun for, potentially making the "
           "actual number of warm-up runs to be greater than warmup_runs"),
-      CreateFlag<int32_t>(
-          "profile_num_runs", &params_,
-          "expected number of runs for profiling"),
-      CreateFlag<int32_t>(
-          "profile_warmup_runs", &params_,
-          "minimum number of runs performed on profiling"),
       CreateFlag<std::string>("json_path", &params_, "path to json file with "
           "model configurations"),
   };
@@ -139,10 +131,6 @@ void BenchmarkModel::LogParams() {
                    << params_.Get<int32_t>("warmup_runs") << "]";
   TFLITE_LOG(INFO) << "Min warmup runs duration (seconds): ["
                    << params_.Get<float>("warmup_min_secs") << "]";
-  TFLITE_LOG(INFO) << "Profile num runs: ["
-                   << params_.Get<int32_t>("profile_num_runs") << "]";
-  TFLITE_LOG(INFO) << "Profile warmup runs: ["
-                   << params_.Get<int32_t>("profile_warmup_runs") << "]";
 }
 
 TfLiteStatus BenchmarkModel::PrepareInputData() { return kTfLiteOk; }


### PR DESCRIPTION
## Current
* Cannot assign `ProfileConfig.num_warmups` and `ProfileConfig.num_runs`.
* `profile_warmup_runs`, `profile_num_runs` command line arguments in `README.md`.

## Updated
* Assign `ProfileConfig.num_warmups` and `ProfileConfig.num_runs` using config file.
* Remove `profile_warmup_runs`, `profile_num_runs` arguments in `BenchmarkModel`.
* Add `profile_warmup_runs`, `profile_num_runs` config in `README.md`.

## Test
* num_runs, num_warmups are properly set in `Interpreter::Profile(int model_id)`.
![profile_config_test](https://user-images.githubusercontent.com/12844401/127761070-2fb68444-dfef-4ebc-ac11-e327e8c2f40a.png)