### PR TITLE
[hotfix] Call `RemoveAllDelegates` instead of `UndoAllDelegates`

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -1257,10 +1257,8 @@ void Interpreter::InvestigateModelSpec(int model_id) {
     }
 
     // revert changes
-    primary_subgraph->UndoAllDelegates();
+    primary_subgraph->RemoveAllDelegates();
   }
-
-  primary_subgraph->AllocateTensors();
 }
 
 std::pair<int, int64_t> Interpreter::GetShortestLatency(


### PR DESCRIPTION
Try executing `deeplabv3_mnv2_pascal_train_aug_8bit.tflite` model in our [drive](https://drive.google.com/drive/u/0/folders/1SDzG2NzhOqFN7H9OMR5DtvLOTCNFJRiH).
You will face a segmentation fault when the model runs on the CPU processor.
### Cause of the failure
I have no clear reason why this model fails, but I found out `InvestigateModelSpec` gives cause for the error.
I've replaced `UndoAllDelegates` + `AllocateTensors` to `RemoveAllDelegates` – where `RemoveAllDelegates` includes `UndoAllDelegates` and `AllocateTensors`–, and found out it works.
https://github.com/mrsnu/tflite/blob/01deb06c00443b3746a700eb707382a3e7a1996b/tensorflow/lite/core/subgraph.cc#L1339-L1345