### PR TITLE
[Minor Bug Fix] Update Huawei NPU name from `armnn` to `liteadaptor`

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -4198,9 +4198,9 @@ TfLiteDelegateFlags GetNNAPIDeviceFlag(std::string name) {
 
   if (contains_keywords({
     "google-edgetpu",
-    "armnn", // Huawei (DaVinci NPU)
+    "liteadaptor", // Huawei (DaVinci NPU)
     "neuron-ann", // Mediatek APU
-    "qti-hta", // Hetagon tensor accelerator
+    "qti-hta", // Hexagon tensor accelerator
     "mtk-neuron" // Mediatek APU
     // "mtk-mdla" #TODO(#139) - Mediatek APU for half float
     })) {

--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -180,10 +180,11 @@ Interpreter::Interpreter(ErrorReporter* error_reporter,
   // TODO #23 : Add more nnapi names
   // Possible device runtime names 
   // nnapi : nnapi-default, nnapi-reference
-  // qualcomm hexagon : qti-default, qti-dsp, qti-gpu, qti-hta
-  // google tpu: google-edgetpu
-  // arm npu (DaVinci) : armnn
-  // mediatek APU : neuron-ann, mtk-neuron, mtk-mdla
+  // armnn : armnn
+  // qualcomm : qti-default, qti-gpu, qti-dsp, qti-hta
+  // mediatek : neuron-ann, mtk-gpu, mtk-dsp, mtk-neuron, mtk-mdla
+  // google tpu : google-edgetpu
+  // huawei npu : liteadaptor
   for (const char* device_name : string_device_names_list) {
     if (IsNNAPIDeviceUseful(device_name)) {
       TFLITE_LOG(INFO) << "Available NNAPI device name: " << device_name;


### PR DESCRIPTION
For huawei NPU (kinin), we need to use accelerator name `liteadaptor`.