### PR TITLE
[Bug fix] `Subgraph` cannot detect output tensor from intermediate node to external op

### DIFF
--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -799,11 +799,11 @@ int InterpreterBuilder::AddSubgraph(const ::tflite::Model* model,
         FlatBufferIntArrayToVector(subgraph->inputs());
     std::set<int> subgraph_inputs =
         std::set<int>(subgraph_input_vec.begin(), subgraph_input_vec.end());
-    const std::set<int>& model_all_outputs =
+    const std::set<int>& all_node_outputs  =
         (*interpreter)->GetModelSpec(subgraph_key.model_id).node_output_tensors;
     const std::set<int>& model_outputs =
         (*interpreter)->GetModelSpec(subgraph_key.model_id).output_tensors;
-    std::set_union(model_all_outputs.begin(), model_all_outputs.end(),
+    std::set_union(all_node_outputs .begin(), all_node_outputs .end(),
                    subgraph_inputs.begin(), subgraph_inputs.end(),
                    std::inserter(non_param_tensors, non_param_tensors.end()));
 


### PR DESCRIPTION
## Current problem

Existing `Input` and `Output` tensor detection logic cannot cover cases when an intermediate node outputs to an external node.
 Example: Yellow op of `retinaface_mbv2_quant_160.tflite` should be marked as an output tensor to resolve `ResizeNearestNeighbor`.
![image](https://user-images.githubusercontent.com/9090115/128350083-1b3c1cae-b278-4146-bead-d4bb3fc7370c.png)


## Solution

Utilize external nodes to guess any external reference from the intermediate node to the other subgraph's input.