### PR TITLE
[Minor Bug Fix] Reuse profile

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -233,12 +233,12 @@ Interpreter::Interpreter(ErrorReporter* error_reporter,
   }
 
   // Initialize configurations.
-  if (Init(runtime_config.interpreter_config) != kTfLiteOk) {
-    error_reporter_->Report("Interpreter::Init() failed.");
-    exit(-1);
-  }
   if (planner_->Init(runtime_config.planner_config) != kTfLiteOk) {
     error_reporter_->Report("Planner::Init() failed.");
+    exit(-1);
+  }
+  if (Init(runtime_config.interpreter_config) != kTfLiteOk) {
+    error_reporter_->Report("Interpreter::Init() failed.");
     exit(-1);
   }
   for (auto& worker : workers_) {


### PR DESCRIPTION
### Current
* Cannot save profile
  * `NeedProfile` method check `schedulers_` of `planner_`, but it is set in `Planner::Init`. So when calling `Interpreter::Init`, `NeedProfile` always returns `false` and profile path will not be initialized.
 
### Change
* Initialize interpreter after planner.
  * The planner will wait enqueue well.