### PR TITLE
[Bug fix] Modified to fix aar build error

### DIFF
--- a/tensorflow/lite/java/src/main/native/nativeinterpreterwrapper_jni.cc
+++ b/tensorflow/lite/java/src/main/native/nativeinterpreterwrapper_jni.cc
@@ -396,7 +396,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_createInterpreter(
   tflite::RuntimeConfig runtime_config;
   if (ParseRuntimeConfigFromJson(path, runtime_config) != kTfLiteOk) {
     ThrowException(env, kIllegalArgumentException,
-                   "Runtime Config json path failed");
+                   "Parsing runtime_config json file failed");
     return 0;
   }
 


### PR DESCRIPTION
### Changes
- As the `planner` property in runtime config was replaced with `schedulers`, 
the log of printing it should change as well.
- Modified log message which could confuse users.