### PR TITLE
[hotfix] Infinite loop in `GetSubgraphCandidates`

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -1456,7 +1456,8 @@ std::vector<int> Interpreter::GetSubgraphCandidates(
           break;
         }
       }
-
+      
+      // TODO: Update with subgraph dependency generation logic
       // check whether any output tensor is resolved or not
       for (const int& output_tensor: next_subgraph->outputs()) {
         if (resolved_tensors.find(output_tensor) != resolved_tensors.end()) {


### PR DESCRIPTION
Upcoming `SetPrevSubgraph` logic loosely checks connectivity (mark as next if share any tensor) due to complexity to backtrack all possible subgraph traversal cases.

However, the existing `GetSubgraphCandidates` doesn't check the resolution of `output_tensor` which can cause an infinite loop in `retinaface_mbv2_quant_160.tflite` that causes segfault.