### PR TITLE
Update `BufferErrorReporter` to cache last error only

### DIFF
--- a/tensorflow/lite/java/src/main/native/jni_utils.cc
+++ b/tensorflow/lite/java/src/main/native/jni_utils.cc
@@ -68,27 +68,16 @@ BufferErrorReporter::BufferErrorReporter(JNIEnv* env, int limit) {
     return;
   }
   buffer_[0] = '\0';
-  start_idx_ = 0;
-  end_idx_ = limit - 1;
+  limit_ = limit;
 }
 
 BufferErrorReporter::~BufferErrorReporter() { delete[] buffer_; }
 
 int BufferErrorReporter::Report(const char* format, va_list args) {
-  int size = 0;
-  // If an error has already been logged, insert a newline.
-  if (start_idx_ > 0 && start_idx_ < end_idx_) {
-    buffer_[start_idx_++] = '\n';
-    ++size;
-  }
-  if (start_idx_ < end_idx_) {
-    size = vsnprintf(buffer_ + start_idx_, end_idx_ - start_idx_, format, args);
-  }
-  start_idx_ += size;
-  return size;
+  return vsnprintf(buffer_, limit_, format, args);
 }
 
-const char* BufferErrorReporter::CachedErrorMessage() { return buffer_; }
+const char* BufferErrorReporter::CachedLastErrorMessage() { return buffer_; }
 
 }  // namespace jni
 }  // namespace tflite

--- a/tensorflow/lite/java/src/main/native/jni_utils.h
+++ b/tensorflow/lite/java/src/main/native/jni_utils.h
@@ -48,12 +48,11 @@ class BufferErrorReporter : public ErrorReporter {
   BufferErrorReporter(JNIEnv* env, int limit);
   virtual ~BufferErrorReporter();
   int Report(const char* format, va_list args) override;
-  const char* CachedErrorMessage();
+  const char* CachedLastErrorMessage();
 
  private:
   char* buffer_;
-  int start_idx_ = 0;
-  int end_idx_ = 0;
+  int limit_;
 };
 
 }  // namespace jni

--- a/tensorflow/lite/java/src/main/native/nativeinterpreterwrapper_jni.cc
+++ b/tensorflow/lite/java/src/main/native/nativeinterpreterwrapper_jni.cc
@@ -349,7 +349,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_createModel(
     ThrowException(env, kIllegalArgumentException,
                    "Contents of %s does not encode a valid "
                    "TensorFlow Lite model: %s",
-                   path, error_reporter->CachedErrorMessage());
+                   path, error_reporter->CachedLastErrorMessage());
     env->ReleaseStringUTFChars(model_file, path);
     return 0;
   }
@@ -377,7 +377,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_createModelWithBuffer(
   if (!model) {
     ThrowException(env, kIllegalArgumentException,
                    "ByteBuffer does not encode a valid model: %s",
-                   error_reporter->CachedErrorMessage());
+                   error_reporter->CachedLastErrorMessage());
     return 0;
   }
   return reinterpret_cast<jlong>(model.release());
@@ -438,7 +438,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_registerModel(
   if (model_id == -1) {
     ThrowException(env, kIllegalArgumentException,
                    "Internal error: Cannot create interpreter: %s",
-                   error_reporter->CachedErrorMessage());
+                   error_reporter->CachedLastErrorMessage());
   }
   interpreter.release();
 
@@ -529,7 +529,7 @@ JNIEXPORT void JNICALL Java_org_tensorflow_lite_NativeInterpreterWrapper_wait(
       if (status != kTfLiteOk) {
         ThrowException(env, kIllegalArgumentException,
                       "Internal error: Failed to copy %d-th output of job %d: %s",
-                      i, job_ids_vector[i], error_reporter->CachedErrorMessage());
+                      i, job_ids_vector[i], error_reporter->CachedLastErrorMessage());
         return;
       }
     }
@@ -599,7 +599,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_resizeInput(
         if (status != kTfLiteOk) {
           ThrowException(env, kIllegalArgumentException,
                         "Internal error: Failed to resize %d-th input: %s",
-                        input_idx, error_reporter->CachedErrorMessage());
+                        input_idx, error_reporter->CachedLastErrorMessage());
           return JNI_FALSE;
         }
       }
@@ -631,7 +631,7 @@ Java_org_tensorflow_lite_NativeInterpreterWrapper_resetVariableTensors(
       if (status != kTfLiteOk) {
         ThrowException(env, kIllegalArgumentException,
                       "Internal error: Failed to reset variable tensors: %s",
-                      error_reporter->CachedErrorMessage());
+                      error_reporter->CachedLastErrorMessage());
       }
     }
   }


### PR DESCRIPTION
The current `BufferErrorReporter` is a bit useless for debugging due to the number of cached error messages and the current JNI logic doesn't always have a counter-part logic of `Interpreter` to keep the log up to date.

Instead, Let `BufferErrorReporter` keep the latest log message for better debugging on the App side.