### PR TITLE
[hotfix] Check Worker::IsBusy() in Planner::GetIdleDevices()

### DIFF
--- a/tensorflow/lite/planner/planner.cc
+++ b/tensorflow/lite/planner/planner.cc
@@ -193,7 +193,8 @@ std::set<TfLiteDeviceFlags> Planner::GetIdleDevices() {
   std::set<TfLiteDeviceFlags> idle_devices;
   for (int i = 0; i < kTfLiteNumDevices; ++i) {
     TfLiteDeviceFlags device_flag = static_cast<TfLiteDeviceFlags>(i);
-    if (device_waiting_[device_flag] == 0) {
+    Worker* worker = GetInterpreter()->GetWorker(device_flag);
+    if (worker != nullptr && !worker->IsBusy()) {
       idle_devices.insert(device_flag);
     }
   }


### PR DESCRIPTION
There exists a corner case in which a worker's waiting time (`GetWaitingTime()`) is 0, but the worker isn't actually busy (`IsBusy()`). This case occurs when the profiled execution time is smaller than the actual execution time.

This resulted in a misunderstanding in `Planner::GetIdleDevices()`, where the Planner would regard a busy worker as idle because the waiting time was zero. This PR changes the function to check `IsBusy()` instead of relying on the waiting time.