### PR TITLE
Reduce scheduling overhead in GetShortestLatency

### DIFF
--- a/tensorflow/lite/interpreter.h
+++ b/tensorflow/lite/interpreter.h
@@ -712,6 +712,7 @@ class Interpreter {
       std::map<TfLiteDeviceFlags, int64_t>& device_waiting,
       int preceded_subgraph_index = -1);
 
+  // hash function to use pair<int, set<int>> as map key in cache_
   struct PairHash {
     std::size_t operator() (const std::pair<int, std::set<int>> &p) const {
       auto hash_func = std::hash<int>();
@@ -723,6 +724,7 @@ class Interpreter {
     }
   };
 
+  // cache for GetShortestLatency()
   std::unordered_map<std::pair<int, std::set<int>>, std::pair<int, int64_t>, PairHash> cache_;
 
   // Generate subgraphs for fallback ops in `model_id`.


### PR DESCRIPTION
This PR adds a cache feature to `Interpreter::GetShortestLatency()` so that the scheduler doesn't have to do a long traversal through all possible subgraph paths every time, when retrieving the shortest latency.

The cache is the form of {model_id, resolved_tensors} --> {best_subgraph_idx, expected_latency (when start_time == 0)}.
Note that the cache isn't always usable at runtime because one or more devices may be busy, i.e. `device_waiting_time[device] > 0`. The best subgraph is dependent on the waiting times, so we can't just do a lookup on the cache at all times without checking the waiting times. This PR solves this issue by comparing `start_time` (a function param of `GetShortestLatency()`) with the device waiting times: if `start_time` is larger than all waiting times, then the situation is the same as if the device waiting times were all zero so it is safe to do a cache lookup.

Big thanks to @dostos for suggesting this cache idea, as well as finding a critical bug in a previous version of this PR.