### PR TITLE
Execute the job right away when it is planned

### DIFF
--- a/tensorflow/lite/planner/planner.cc
+++ b/tensorflow/lite/planner/planner.cc
@@ -163,6 +163,10 @@ void Planner::EnqueueToWorkers(ScheduleAction& action) {
     auto device = queue.first;
     auto& requests = queue.second;
 
+    if (requests.empty()) {
+      continue;
+    }
+
     Worker* worker = GetInterpreter()->GetWorker(device);
     if (worker == nullptr) return;
     {
@@ -473,9 +477,7 @@ void Planner::Plan() {
     do {
       need_reschedule_ = false;
       for (size_t i = 0; i < local_queues_.size(); ++i) {
-        UpdateDeviceWaitingTime();
         schedulers_[i]->Schedule(local_queues_[i]);
-        EnqueueToWorkers(schedulers_[i]->GetAction());
       }
     } while(need_reschedule_);
   }
@@ -484,6 +486,7 @@ void Planner::Plan() {
 void Scheduler::EnqueueAction(Job job, Subgraph* subgraph) {
   planner_->UpdateJobScheduleStatus(job, subgraph);
   action_[subgraph->GetKey().device_flag].push_back(job);
+  planner_->EnqueueToWorkers(action_);
 }
 
 }  // namespace impl

--- a/tensorflow/lite/planner/shortest_expected_latency_scheduler.cc
+++ b/tensorflow/lite/planner/shortest_expected_latency_scheduler.cc
@@ -6,13 +6,13 @@ namespace tflite {
 namespace impl {
 
 void ShortestExpectedLatencyScheduler::Schedule(JobQueue& requests) {
-  DeviceWaitingTime device_waiting = GetDeviceWaitingTime();
   JobQueue local_jobs;
   int window_size = std::min(planner_->GetWindowSize(), (int)requests.size());
   local_jobs.insert(local_jobs.begin(), requests.begin(),
                     requests.begin() + window_size);
   requests.erase(requests.begin(), requests.begin() + window_size);
   while (!local_jobs.empty()) {
+    planner_->UpdateDeviceWaitingTime();
     // First, find the most urgent job -- the one with the
     // largest shortest latency (no, that's not a typo).
     // Put that job into some worker, and repeat this whole loop until we've
@@ -53,7 +53,7 @@ void ShortestExpectedLatencyScheduler::Schedule(JobQueue& requests) {
         best_subgraph = cache_it->second;
       } else {
         best_subgraph = GetInterpreter()->GetShortestLatency(
-            next_job.model_id, next_job.resolved_tensors, 0, device_waiting,
+            next_job.model_id, next_job.resolved_tensors, 0, GetDeviceWaitingTime(),
             preceded_subgraph_index);
 
         // insert new value into cache
@@ -86,9 +86,6 @@ void ShortestExpectedLatencyScheduler::Schedule(JobQueue& requests) {
       most_urgent_job.expected_latency = largest_shortest_latency;
     }
     EnqueueAction(most_urgent_job, target_subgraph);
-
-    device_waiting[target_subgraph->GetKey().device_flag] +=
-        largest_shortest_latency;
   }
 }
 


### PR DESCRIPTION
### Current
schedule all the jobs in the window first and pass them to corresponding workers. Due to the huge scheduling overhead, the jobs ready to be executed should wait and the device waiting time becomes inaccurate.

### Change
* Instead of waiting for the other jobs in the window to be scheduled, execute the first scheduled job.
* Update device waiting time for each iteration.