### PR TITLE
`InvokeModelsSync` bug fix

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -551,8 +551,10 @@ void Interpreter::InvokeModelsSync(std::vector<Job> requests,
                                    std::vector<Tensors> outputs) {
   std::vector<int> job_ids = InvokeModelsAsync(requests, inputs);
   planner_->Wait(job_ids);
-  for (size_t i = 0; i < job_ids.size(); i++) {
-    GetOutputTensors(job_ids[i], outputs[i]);
+  if (inputs.size() == requests.size() && inputs.size() == outputs.size()) {
+    for (size_t i = 0; i < job_ids.size(); i++) {
+      GetOutputTensors(job_ids[i], outputs[i]);
+    }
   }
 }
 


### PR DESCRIPTION
Current `InvokeModelsSync` tries to copy output tensors without any given input.
This bug removes massive tensor copy logs in #179.