### PR TITLE
Rename MockContext to MockEngine

### DIFF
--- a/band/test/planner_test.cc
+++ b/band/test/planner_test.cc
@@ -11,7 +11,7 @@
 namespace band {
 namespace test {
 
-struct MockContext : public MockContextBase {
+struct MockEngine : public MockEngineBase {
   void PrepareReenqueue(Job&) override{};
   void UpdateLatency(const SubgraphKey&, int64_t) override{};
   void EnqueueFinishedJob(Job& job) override { finished.insert(job.job_id); }
@@ -44,7 +44,7 @@ planner -> scheduler -> worker -> planner
 */
 
 TEST(PlannerSuite, SingleQueue) {
-  MockContext engine;
+  MockEngine engine;
   Planner planner(engine);
   auto status = planner.AddScheduler(std::make_unique<MockScheduler>(engine));
   EXPECT_EQ(status, absl::OkStatus());

--- a/band/test/scheduler_test.cc
+++ b/band/test/scheduler_test.cc
@@ -13,14 +13,14 @@
 namespace band {
 namespace test {
 
-struct MockContext : public MockContextBase {
+struct MockEngine : public MockEngineBase {
   std::set<WorkerId> idle_workers_;
   std::vector<WorkerId> list_idle_workers_;
   std::map<ModelId, WorkerId> model_worker_map_;
   std::vector<ScheduleAction> action_;
   mutable int w;
 
-  MockContext(std::set<WorkerId> idle_workers) : idle_workers_(idle_workers) {
+  MockEngine(std::set<WorkerId> idle_workers) : idle_workers_(idle_workers) {
     w = 0;
     list_idle_workers_.assign(idle_workers.begin(), idle_workers.end());
   }
@@ -96,7 +96,7 @@ TEST_P(LSTTestsFixture, LSTTest) {
   }
   const int count_requests = requests.size();
 
-  MockContext engine(available_workers);
+  MockEngine engine(available_workers);
   LeastSlackFirstScheduler lst_scheduler(engine, 5);
   lst_scheduler.Schedule(requests);
 
@@ -127,7 +127,7 @@ TEST_P(ModelLevelTestsFixture, RoundRobinTest) {
   }
   const int count_requests = requests.size();
 
-  MockContext engine(available_workers);
+  MockEngine engine(available_workers);
   RoundRobinScheduler rr_scheduler(engine);
   rr_scheduler.Schedule(requests);
 
@@ -152,7 +152,7 @@ TEST_P(ConfigLevelTestsFixture, FixedDeviceFixedWorkerTest) {
   }
   const int count_requests = requests.size();
 
-  MockContext engine(available_workers);
+  MockEngine engine(available_workers);
   FixedWorkerScheduler fd_scheduler(engine);
   fd_scheduler.Schedule(requests);
 
@@ -192,7 +192,7 @@ TEST_P(ConfigLevelTestsFixture, FixedDeviceFixedWorkerEngineRequestTest) {
   }
   const int count_requests = requests.size();
 
-  MockContext engine(available_workers);
+  MockEngine engine(available_workers);
   FixedWorkerScheduler fd_scheduler(engine);
   fd_scheduler.Schedule(requests);
 

--- a/band/test/test_util.h
+++ b/band/test/test_util.h
@@ -9,8 +9,8 @@
 namespace band {
 namespace test {
 
-struct MockContextBase : public IEngine {
-  MockContextBase() = default;
+struct MockEngineBase : public IEngine {
+  MockEngineBase() = default;
 
   MOCK_CONST_METHOD0(UpdateWorkersWaiting, void(void));
   MOCK_CONST_METHOD0(GetWorkerWaitingTime, WorkerWaitingTime(void));

--- a/band/test/worker_test.cc
+++ b/band/test/worker_test.cc
@@ -11,7 +11,7 @@
 namespace band {
 namespace test {
 
-struct MockContext : public MockContextBase {
+struct MockEngine : public MockEngineBase {
   void EnqueueFinishedJob(Job& job) override { finished.insert(job.job_id); }
   absl::Status Invoke(const SubgraphKey& key) override {
     time::SleepForMicros(50);
@@ -33,7 +33,7 @@ Job GetEmptyJob() {
 }
 
 TYPED_TEST(WorkerSuite, JobHelper) {
-  MockContext engine;
+  MockEngine engine;
   TypeParam worker(&engine, 0, DeviceFlag::kCPU);
   Job job = GetEmptyJob();
 
@@ -50,7 +50,7 @@ TYPED_TEST(WorkerSuite, JobHelper) {
 }
 
 TYPED_TEST(WorkerSuite, Wait) {
-  MockContext engine;
+  MockEngine engine;
   EXPECT_CALL(engine, UpdateLatency).Times(testing::AtLeast(1));
   EXPECT_CALL(engine, Trigger).Times(testing::AtLeast(1));
   EXPECT_CALL(engine, TryCopyInputTensors).Times(testing::AtLeast(1));


### PR DESCRIPTION
Rename `MockContext*` to `MockEngine*` as we renamed `Context` to `IEngine`.