### PR TITLE
Quick fix for minor bugs found when running benchmark

### DIFF
--- a/band/c/c_api_internal.cc
+++ b/band/c/c_api_internal.cc
@@ -19,8 +19,7 @@ const char* BandSchedulerToString(BandSchedulerType type) {
       return "least_slack_time_first";
     case kBandHeterogeneousEarliestFinishTimeReserved:
       return "heterogeneous_earliest_finish_time_reserved";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }
@@ -46,8 +45,7 @@ const char* BandSubgraphPreparationToString(BandSubgraphPreparationType type) {
       return "unit_subgraph";
     case kBandMergeUnitSubgraph:
       return "merge_unit_subgraph";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }
@@ -89,8 +87,7 @@ const char* BandDataTypeToString(BandDataType type) {
       return "FLOAT16";
     case kBandFloat64:
       return "FLOAT64";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }
@@ -105,8 +102,7 @@ const char* BandDeviceToString(BandDeviceFlag flag) {
       return "DSP";
     case kBandNPU:
       return "NPU";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }
@@ -126,8 +122,7 @@ const char* BandBackendToString(BandBackendType flag) {
   switch (flag) {
     case kBandTfLite:
       return "Tensorflow Lite";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }
@@ -135,7 +130,8 @@ const char* BandBackendToString(BandBackendType flag) {
 const BandBackendType BandBackendGetType(const char* name) {
   for (int i = 0; i < kBandNumBackendType; i++) {
     BandBackendType flag = (BandBackendType)i;
-    if (strcmp(BandBackendToString(flag), name) == 0) {
+    if (strncmp(BandBackendToString(flag), name,
+                strlen(BandBackendToString(flag))) == 0) {
       return flag;
     }
   }
@@ -150,8 +146,7 @@ const char* BandStatusToString(BandStatus status) {
       return "DelegateError";
     case kBandError:
       return "Error";
-    default: {
-    }
+    default: {}
   }
   return "Unknown type";
 }

--- a/band/common.cc
+++ b/band/common.cc
@@ -53,7 +53,7 @@ size_t EnumLength<QuantizationType>() {
 }
 
 template <>
-const char* ToString(BackendType backend_type) {
+std::string ToString(BackendType backend_type) {
   switch (backend_type) {
     case BackendType::kTfLite: {
       return "Tensorflow Lite";
@@ -65,7 +65,7 @@ const char* ToString(BackendType backend_type) {
 }
 
 template <>
-const char* ToString(CPUMaskFlag cpu_mask_flag) {
+std::string ToString(CPUMaskFlag cpu_mask_flag) {
   switch (cpu_mask_flag) {
     case CPUMaskFlag::kAll: {
       return "ALL";
@@ -86,7 +86,7 @@ const char* ToString(CPUMaskFlag cpu_mask_flag) {
 }
 
 template <>
-const char* ToString(SchedulerType scheduler_type) {
+std::string ToString(SchedulerType scheduler_type) {
   switch (scheduler_type) {
     case SchedulerType::kFixedWorker: {
       return "fixed_worker";
@@ -116,7 +116,7 @@ const char* ToString(SchedulerType scheduler_type) {
 }
 
 template <>
-const char* ToString(SubgraphPreparationType subgraph_preparation_type) {
+std::string ToString(SubgraphPreparationType subgraph_preparation_type) {
   switch (subgraph_preparation_type) {
     case SubgraphPreparationType::kNoFallbackSubgraph: {
       return "no_fallback_subgraph";
@@ -137,7 +137,7 @@ const char* ToString(SubgraphPreparationType subgraph_preparation_type) {
 }
 
 template <>
-const char* ToString(DataType data_type) {
+std::string ToString(DataType data_type) {
   switch (data_type) {
     case DataType::kNoType: {
       return "NoType";
@@ -182,7 +182,7 @@ const char* ToString(DataType data_type) {
 }
 
 template <>
-const char* ToString(DeviceFlag device_flag) {
+std::string ToString(DeviceFlag device_flag) {
   switch (device_flag) {
     case DeviceFlag::kCPU: {
       return "CPU";
@@ -203,7 +203,7 @@ const char* ToString(DeviceFlag device_flag) {
 }
 
 template <>
-const char* ToString(JobStatus job_status) {
+std::string ToString(JobStatus job_status) {
   switch (job_status) {
     case JobStatus::kEnqueueFailed: {
       return "EnqueueFailed";
@@ -232,7 +232,7 @@ const char* ToString(JobStatus job_status) {
 }
 
 template <>
-const char* ToString(BufferFormat format_type) {
+std::string ToString(BufferFormat format_type) {
   switch (format_type) {
     case BufferFormat::kGrayScale: {
       return "GrayScale";
@@ -265,7 +265,7 @@ const char* ToString(BufferFormat format_type) {
 }
 
 template <>
-const char* ToString(BufferOrientation format_type) {
+std::string ToString(BufferOrientation format_type) {
   switch (format_type) {
     case BufferOrientation::kTopLeft: {
       return "TopLeft";

--- a/band/common.h
+++ b/band/common.h
@@ -35,7 +35,7 @@ template <typename EnumType>
 EnumType FromString(const char* str) {
   for (size_t i = 0; i < EnumLength<EnumType>(); i++) {
     EnumType t = static_cast<EnumType>(i);
-    if (ToString(t) == str) {
+    if (strcmp(ToString(t), str) == 0) {
       return t;
     }
   }

--- a/band/common.h
+++ b/band/common.h
@@ -26,16 +26,16 @@ size_t EnumLength() {
 }
 
 template <typename EnumType>
-const char* ToString(EnumType t) {
+std::string ToString(EnumType t) {
   assert(false && "ToString is not implemented for this type.");
   return "";
 }
 
 template <typename EnumType>
-EnumType FromString(const char* str) {
+EnumType FromString(std::string str) {
   for (size_t i = 0; i < EnumLength<EnumType>(); i++) {
     EnumType t = static_cast<EnumType>(i);
-    if (strcmp(ToString(t), str) == 0) {
+    if (ToString(t) == str) {
       return t;
     }
   }
@@ -164,25 +164,25 @@ template <>
 size_t EnumLength<QuantizationType>();
 
 template <>
-const char* ToString(BackendType backend_type);
+std::string ToString(BackendType backend_type);
 template <>
-const char* ToString(SchedulerType scheduler_type);
+std::string ToString(SchedulerType scheduler_type);
 template <>
-const char* ToString(CPUMaskFlag cpu_mask_flag);
+std::string ToString(CPUMaskFlag cpu_mask_flag);
 template <>
-const char* ToString(SubgraphPreparationType subgraph_preparation_type);
+std::string ToString(SubgraphPreparationType subgraph_preparation_type);
 template <>
-const char* ToString(DataType data_type);
+std::string ToString(DataType data_type);
 template <>
-const char* ToString(BufferFormat buffer_format);
+std::string ToString(BufferFormat buffer_format);
 template <>
-const char* ToString(BufferOrientation buffer_orientation);
+std::string ToString(BufferOrientation buffer_orientation);
 template <>
-const char* ToString(DeviceFlag device_flag);
+std::string ToString(DeviceFlag device_flag);
 template <>
-const char* ToString(QuantizationType);
+std::string ToString(QuantizationType);
 template <>
-const char* ToString(JobStatus job_status);
+std::string ToString(JobStatus job_status);
 
 struct AffineQuantizationParams {
   std::vector<float> scale;

--- a/band/resource_monitor.cc
+++ b/band/resource_monitor.cc
@@ -84,7 +84,7 @@ size_t EnumLength<CpuFreqFlag>() {
 }
 
 template <>
-const char* ToString<ThermalFlag>(ThermalFlag flag) {
+std::string ToString<ThermalFlag>(ThermalFlag flag) {
   switch (flag) {
     case ThermalFlag::TZ_TEMPERATURE:
       return "TZ_TEMPERATURE";
@@ -94,7 +94,7 @@ const char* ToString<ThermalFlag>(ThermalFlag flag) {
 }
 
 template <>
-const char* ToString<DevFreqFlag>(DevFreqFlag flag) {
+std::string ToString<DevFreqFlag>(DevFreqFlag flag) {
   switch (flag) {
     case DevFreqFlag::CUR_FREQ:
       return "CUR_FREQ";
@@ -112,7 +112,7 @@ const char* ToString<DevFreqFlag>(DevFreqFlag flag) {
 }
 
 template <>
-const char* ToString<CpuFreqFlag>(CpuFreqFlag flag) {
+std::string ToString<CpuFreqFlag>(CpuFreqFlag flag) {
   switch (flag) {
     case CpuFreqFlag::CUR_FREQ:
       return "CUR_FREQ";

--- a/band/resource_monitor.h
+++ b/band/resource_monitor.h
@@ -51,11 +51,11 @@ template <>
 size_t EnumLength<CpuFreqFlag>();
 
 template <>
-const char* ToString<ThermalFlag>(ThermalFlag flag);
+std::string ToString<ThermalFlag>(ThermalFlag flag);
 template <>
-const char* ToString<DevFreqFlag>(DevFreqFlag flag);
+std::string ToString<DevFreqFlag>(DevFreqFlag flag);
 template <>
-const char* ToString<CpuFreqFlag>(CpuFreqFlag flag);
+std::string ToString<CpuFreqFlag>(CpuFreqFlag flag);
 
 class ResourceMonitor {
  public:

--- a/script/utils/docker.py
+++ b/script/utils/docker.py
@@ -10,11 +10,11 @@ def get_container_hash(keyword="vsc-band"):
 def copy_docker(src, dst, hash=None):
     if hash is None:
         hash = get_container_hash()[0]
-    subprocess.call(f'mkdir -p {dst}')
-    subprocess.call(f'sh script/utils/docker_util.sh -d {hash} {src} {dst}')
+    subprocess.call(['mkdir',  '-p', '{dst}'])
+    subprocess.call(['sh', 'script/utils/docker_util.sh', '-d', hash, src, dst])
 
 
 def run_cmd_docker(exec, hash=None):
     if hash is None:
         hash = get_container_hash()[0]
-    subprocess.call(f'sh script/utils/docker_util.sh -r {hash} {exec}')
+    subprocess.call(['sh', 'script/utils/docker_util.sh', '-r', hash, exec])


### PR DESCRIPTION
* `subprocess.call` requires list of arguments instead of a string.
* Comparison of two strings requires the usage of `strcmp`.