### PR TITLE
Multiple `on_end_request` callbacks & unset support 

### DIFF
--- a/band/c/c_api.cc
+++ b/band/c/c_api.cc
@@ -330,11 +330,10 @@ BandStatus BandEngineWait(BandEngine* engine, BandRequestHandle handle,
       handle, BandTensorArrayToVec(output_tensors, num_outputs)));
 }
 
-void BandEngineSetOnEndRequest(BandEngine* engine,
-                               void (*on_end_invoke)(void* user_data,
-                                                     int job_id,
-                                                     BandStatus status),
-                               void* user_data) {
+BandCallbackHandle BandEngineSetOnEndRequest(
+    BandEngine* engine,
+    void (*on_end_invoke)(void* user_data, int job_id, BandStatus status),
+    void* user_data) {
   auto user_data_invoke = std::bind(
       on_end_invoke, user_data, std::placeholders::_1, std::placeholders::_2);
   std::function<void(int, absl::Status)> new_on_end_invoke =
@@ -342,6 +341,11 @@ void BandEngineSetOnEndRequest(BandEngine* engine,
         user_data_invoke(job_id, ToBandStatus(status));
       };
   return engine->impl->SetOnEndRequest(new_on_end_invoke);
+}
+
+BandStatus BandEngineUnsetOnEndRequest(BandEngine* engine,
+                                       BandCallbackHandle handle) {
+  return ToBandStatus(engine->impl->UnsetOnEndRequest(handle));
 }
 
 #ifdef __cplusplus

--- a/band/c/c_api.h
+++ b/band/c/c_api.h
@@ -33,6 +33,7 @@ typedef struct BandModel BandModel;
 typedef struct BandTensor BandTensor;
 typedef struct BandEngine BandEngine;
 typedef int BandRequestHandle;
+typedef int BandCallbackHandle;
 
 /* config builder */
 BAND_CAPI_EXPORT extern BandConfigBuilder* BandConfigBuilderCreate();
@@ -107,10 +108,13 @@ BAND_CAPI_EXPORT extern BandStatus BandEngineWait(BandEngine* engine,
                                                   BandRequestHandle handle,
                                                   BandTensor** output_tensors,
                                                   size_t num_outputs);
-BAND_CAPI_EXPORT extern void BandEngineSetOnEndRequest(
+BAND_CAPI_EXPORT extern BandCallbackHandle BandEngineSetOnEndRequest(
     BandEngine* engine,
-    void (*on_end_invoke)(void* user_data, int job_id, BandStatus status),
+    void (*on_end_invoke)(void* user_data, BandRequestHandle job_id,
+                          BandStatus status),
     void* user_data);
+BAND_CAPI_EXPORT extern BandStatus BandEngineUnsetOnEndRequest(
+    BandEngine* engine, BandCallbackHandle callback_handle);
 
 typedef BandConfigBuilder* (*PFN_BandConfigBuilderCreate)();
 typedef void (*PFN_BandAddConfig)(BandConfigBuilder*, int, int, ...);
@@ -155,9 +159,10 @@ typedef BandRequestHandle (*PFN_BandEngineRequestAsyncOptions)(
     BandEngine*, BandModel*, BandRequestOption, BandTensor**);
 typedef BandStatus (*PFN_BandEngineWait)(BandEngine*, BandRequestHandle,
                                          BandTensor**, size_t);
-typedef void (*PFN_BandEngineSetOnEndRequest)(BandEngine*,
-                                              void (*)(void*, int, BandStatus),
-                                              void*);
+typedef BandCallbackHandle (*PFN_BandEngineSetOnEndRequest)(
+    BandEngine*, void (*)(void*, int, BandStatus), void*);
+typedef BandStatus (*PFN_BandEngineUnsetOnEndRequest)(BandEngine*,
+                                                      BandCallbackHandle);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/band/common.h
+++ b/band/common.h
@@ -15,6 +15,7 @@ namespace band {
 typedef int WorkerId;
 typedef int ModelId;
 typedef int JobId;
+typedef int CallbackId;
 
 using BitMask = std::bitset<64>;
 

--- a/band/engine.cc
+++ b/band/engine.cc
@@ -490,8 +490,8 @@ CallbackId Engine::SetOnEndRequest(
   return planner_->SetOnEndRequest(on_end_request);
 }
 
-void Engine::UnsetOnEndRequest(CallbackId callback_id) {
-  planner_->UnsetOnEndRequest(callback_id);
+absl::Status Engine::UnsetOnEndRequest(CallbackId callback_id) {
+  return planner_->UnsetOnEndRequest(callback_id);
 }
 
 absl::Status Engine::Init(const RuntimeConfig& config) {
@@ -760,7 +760,8 @@ Engine::GetShortestLatencyWithUnitSubgraph(
 
   // Initialize memo.
   for (int i = 0; i < num_unit_subgraphs; ++i) {
-    memo[i] = std::make_pair<std::vector<SubgraphKey>, int64_t>({}, std::numeric_limits<int>::max());
+    memo[i] = std::make_pair<std::vector<SubgraphKey>, int64_t>(
+        {}, std::numeric_limits<int>::max());
   }
 
   // `i` and `j` refer to an unit subgraph idx.

--- a/band/engine.cc
+++ b/band/engine.cc
@@ -17,7 +17,6 @@
 #include "band/planner.h"
 #include "band/tensor.h"
 #include "band/worker.h"
-#include "engine.h"
 
 namespace band {
 

--- a/band/engine.cc
+++ b/band/engine.cc
@@ -17,6 +17,7 @@
 #include "band/planner.h"
 #include "band/tensor.h"
 #include "band/worker.h"
+#include "engine.h"
 
 namespace band {
 
@@ -484,9 +485,13 @@ absl::Status Engine::GetOutputTensors(JobId job_id, Tensors outputs) {
   return absl::OkStatus();
 }
 
-void Engine::SetOnEndRequest(
+CallbackId Engine::SetOnEndRequest(
     std::function<void(int, absl::Status)> on_end_request) {
-  planner_->SetOnEndRequest(on_end_request);
+  return planner_->SetOnEndRequest(on_end_request);
+}
+
+void Engine::UnsetOnEndRequest(CallbackId callback_id) {
+  planner_->UnsetOnEndRequest(callback_id);
 }
 
 absl::Status Engine::Init(const RuntimeConfig& config) {

--- a/band/engine.h
+++ b/band/engine.h
@@ -88,7 +88,9 @@ class Engine : public IEngine {
   absl::Status GetOutputTensors(JobId job_id, Tensors outputs = {});
 
   // Sets the callback function pointer to report the end of invoke.
-  void SetOnEndRequest(std::function<void(int, absl::Status)> on_end_request);
+  CallbackId SetOnEndRequest(
+      std::function<void(int, absl::Status)> on_end_request);
+  void UnsetOnEndRequest(CallbackId callback_id);
 
   int64_t GetProfiled(const SubgraphKey& key) const override;
   int64_t GetExpected(const SubgraphKey& key) const override;

--- a/band/engine.h
+++ b/band/engine.h
@@ -90,7 +90,7 @@ class Engine : public IEngine {
   // Sets the callback function pointer to report the end of invoke.
   CallbackId SetOnEndRequest(
       std::function<void(int, absl::Status)> on_end_request);
-  void UnsetOnEndRequest(CallbackId callback_id);
+  absl::Status UnsetOnEndRequest(CallbackId callback_id);
 
   int64_t GetProfiled(const SubgraphKey& key) const override;
   int64_t GetExpected(const SubgraphKey& key) const override;

--- a/band/planner.cc
+++ b/band/planner.cc
@@ -13,7 +13,6 @@
 #include "band/scheduler/round_robin_scheduler.h"
 #include "band/scheduler/shortest_expected_latency_scheduler.h"
 #include "band/time.h"
-#include "planner.h"
 
 namespace band {
 

--- a/band/planner.cc
+++ b/band/planner.cc
@@ -186,10 +186,13 @@ void Planner::EnqueueFinishedJob(Job& job) {
   finished_lock.unlock();
 
   // report end invoke using callback
-  if (on_end_request_ && job.require_callback && is_finished) {
-    on_end_request_(job.job_id, job.status == JobStatus::kSuccess
-                                    ? absl::OkStatus()
-                                    : absl::InternalError("Job failed."));
+  if (job.require_callback && is_finished) {
+    std::unique_lock<std::mutex> callback_lock(on_end_request_mtx_);
+    for (auto& id_callback : on_end_request_callbacks_) {
+      id_callback.second(job.job_id, job.status == JobStatus::kSuccess
+                                         ? absl::OkStatus()
+                                         : absl::InternalError("Job failed."));
+    }
   }
 }
 

--- a/band/planner.cc
+++ b/band/planner.cc
@@ -235,14 +235,18 @@ CallbackId Planner::SetOnEndRequest(
     std::function<void(int, absl::Status)> on_end_request) {
   std::lock_guard<std::mutex> lock(on_end_request_mtx_);
   on_end_request_callbacks_[next_callback_id_] = on_end_request;
+  return next_callback_id_++;
 }
 
-void Planner::UnsetOnEndRequest(CallbackId callback_id) {
+absl::Status Planner::UnsetOnEndRequest(CallbackId callback_id) {
   std::lock_guard<std::mutex> lock(on_end_request_mtx_);
-  if (on_end_request_callbacks_.find(callback_id) !=
+  if (on_end_request_callbacks_.find(callback_id) ==
       on_end_request_callbacks_.end()) {
-    on_end_request_callbacks_.erase(callback_id);
+    return absl::InternalError("Callback id not found.");
   }
+
+  on_end_request_callbacks_.erase(callback_id);
+  return absl::OkStatus();
 }
 
 int Planner::GetWorkerType() const {

--- a/band/planner.h
+++ b/band/planner.h
@@ -68,7 +68,10 @@ class Planner {
     return model_execution_count_;
   }
   // Sets the callback function pointer to report the end of invoke.
-  void SetOnEndRequest(std::function<void(int, absl::Status)> on_end_request);
+  CallbackId SetOnEndRequest(
+      std::function<void(int, absl::Status)> on_end_request);
+  void UnsetOnEndRequest(CallbackId callback_id);
+
   // Get the Job instance with the `job_id`.
   Job GetFinishedJob(int job_id);
   // Get which worker types the schedulers require.
@@ -102,7 +105,10 @@ class Planner {
   // Jobs Finished
   std::map<int, int> model_execution_count_;
 
-  std::function<void(int, absl::Status)> on_end_request_;
+  mutable std::mutex on_end_request_mtx_;
+  std::map<CallbackId, std::function<void(int, absl::Status)>>
+      on_end_request_callbacks_;
+  CallbackId next_callback_id_ = 0;
 
   // Request Queue
   ConcurrentJobQueue requests_;

--- a/band/planner.h
+++ b/band/planner.h
@@ -70,7 +70,7 @@ class Planner {
   // Sets the callback function pointer to report the end of invoke.
   CallbackId SetOnEndRequest(
       std::function<void(int, absl::Status)> on_end_request);
-  void UnsetOnEndRequest(CallbackId callback_id);
+  absl::Status UnsetOnEndRequest(CallbackId callback_id);
 
   // Get the Job instance with the `job_id`.
   Job GetFinishedJob(int job_id);

--- a/band/test/c/c_api_test.cc
+++ b/band/test/c/c_api_test.cc
@@ -187,12 +187,13 @@ TEST(CApi, EngineSimpleAsyncInvoke) {
   EXPECT_EQ(BandTensorGetDims(output_tensor)[1], 8);
   EXPECT_EQ(BandTensorGetDims(output_tensor)[2], 8);
   EXPECT_EQ(BandTensorGetDims(output_tensor)[3], 3);
-#endif  // BAND_TFLITE
 
   EXPECT_EQ(BandEngineUnsetOnEndRequest(engine, callback_handle), kBandOk);
 
   BandTensorDelete(input_tensor);
   BandTensorDelete(output_tensor);
+#endif  // BAND_TFLITE
+
   BandEngineDelete(engine);
   BandConfigDelete(config);
   BandModelDelete(model);

--- a/band/test/c/c_api_test.cc
+++ b/band/test/c/c_api_test.cc
@@ -53,7 +53,7 @@ TEST(CApi, ModelLoad) {
   BandModelDelete(model);
 }
 
-TEST(CApi, EngineSimpleInvoke) {
+TEST(CApi, EngineSimpleSyncInvoke) {
   BandConfigBuilder* b = BandConfigBuilderCreate();
   BandAddConfig(b, BAND_PLANNER_LOG_PATH, /*count=*/1,
                 "band/test/data/log.json");
@@ -113,6 +113,86 @@ TEST(CApi, EngineSimpleInvoke) {
   BandTensorDelete(input_tensor);
   BandTensorDelete(output_tensor);
 #endif  // BAND_TFLITE
+  BandEngineDelete(engine);
+  BandConfigDelete(config);
+  BandModelDelete(model);
+}
+
+TEST(CApi, EngineSimpleAsyncInvoke) {
+  BandConfigBuilder* b = BandConfigBuilderCreate();
+  BandAddConfig(b, BAND_PLANNER_LOG_PATH, /*count=*/1,
+                "band/test/data/log.json");
+  BandAddConfig(b, BAND_PLANNER_SCHEDULERS, /*count=*/1, kBandRoundRobin);
+  BandAddConfig(b, BAND_MINIMUM_SUBGRAPH_SIZE, /*count=*/1, 7);
+  BandAddConfig(b, BAND_SUBGRAPH_PREPARATION_TYPE, /*count=*/1,
+                kBandMergeUnitSubgraph);
+  BandAddConfig(b, BAND_CPU_MASK, /*count=*/1, kBandAll);
+  BandAddConfig(b, BAND_PLANNER_CPU_MASK, /*count=*/1, kBandPrimary);
+  BandAddConfig(b, BAND_WORKER_WORKERS, /*count=*/2, kBandCPU, kBandCPU);
+  BandAddConfig(b, BAND_WORKER_NUM_THREADS, /*count=*/2, 3, 4);
+  BandAddConfig(b, BAND_WORKER_CPU_MASKS, /*count=*/2, kBandBig, kBandLittle);
+  BandAddConfig(b, BAND_PROFILE_SMOOTHING_FACTOR, /*count=*/1, 0.1f);
+  BandAddConfig(b, BAND_PROFILE_DATA_PATH, /*count=*/1,
+                "band/test/data/profile.json");
+  BandAddConfig(b, BAND_PROFILE_ONLINE, /*count=*/1, true);
+  BandAddConfig(b, BAND_PROFILE_NUM_WARMUPS, /*count=*/1, 1);
+  BandAddConfig(b, BAND_PROFILE_NUM_RUNS, /*count=*/1, 1);
+  BandAddConfig(b, BAND_WORKER_ALLOW_WORKSTEAL, /*count=*/1, true);
+  BandAddConfig(b, BAND_WORKER_AVAILABILITY_CHECK_INTERVAL_MS, /*count=*/1,
+                30000);
+  BandAddConfig(b, BAND_PLANNER_SCHEDULE_WINDOW_SIZE, /*count=*/1, 10);
+  BandConfig* config = BandConfigCreate(b);
+  EXPECT_NE(config, nullptr);
+
+  BandEngine* engine = BandEngineCreate(config);
+  EXPECT_NE(engine, nullptr);
+
+  BandModel* model = BandModelCreate();
+  EXPECT_NE(model, nullptr);
+
+  bool is_finished = false;
+  auto callback = [](void* user_data, BandRequestHandle handle, BandStatus s) {
+    bool* is_finished = reinterpret_cast<bool*>(user_data);
+    *is_finished = true;
+  };
+
+  BandCallbackHandle callback_handle =
+      BandEngineSetOnEndRequest(engine, callback, &is_finished);
+
+#ifdef BAND_TFLITE
+  EXPECT_EQ(
+      BandModelAddFromFile(model, kBandTfLite, "band/test/data/add.tflite"),
+      kBandOk);
+  EXPECT_EQ(BandEngineRegisterModel(engine, model), kBandOk);
+  EXPECT_EQ(BandEngineGetNumInputTensors(engine, model), 1);
+  EXPECT_EQ(BandEngineGetNumOutputTensors(engine, model), 1);
+
+  BandTensor* input_tensor = BandEngineCreateInputTensor(engine, model, 0);
+  BandTensor* output_tensor = BandEngineCreateOutputTensor(engine, model, 0);
+
+  std::array<float, 2> input = {1.f, 3.f};
+  memcpy(BandTensorGetData(input_tensor), input.data(),
+         input.size() * sizeof(float));
+  BandRequestHandle handle =
+      BandEngineRequestAsync(engine, model, &input_tensor);
+
+  EXPECT_EQ(BandEngineWait(engine, handle, &output_tensor, 1), kBandOk);
+  EXPECT_EQ(is_finished, true);
+
+  EXPECT_EQ(reinterpret_cast<float*>(BandTensorGetData(output_tensor))[0], 3.f);
+  EXPECT_EQ(reinterpret_cast<float*>(BandTensorGetData(output_tensor))[1], 9.f);
+
+  EXPECT_EQ(BandTensorGetNumDims(output_tensor), 4);
+  EXPECT_EQ(BandTensorGetDims(output_tensor)[0], 1);
+  EXPECT_EQ(BandTensorGetDims(output_tensor)[1], 8);
+  EXPECT_EQ(BandTensorGetDims(output_tensor)[2], 8);
+  EXPECT_EQ(BandTensorGetDims(output_tensor)[3], 3);
+#endif  // BAND_TFLITE
+
+  EXPECT_EQ(BandEngineUnsetOnEndRequest(engine, callback_handle), kBandOk);
+
+  BandTensorDelete(input_tensor);
+  BandTensorDelete(output_tensor);
   BandEngineDelete(engine);
   BandConfigDelete(config);
   BandModelDelete(model);


### PR DESCRIPTION
### List of changes
- Support multiple callbacks to the engine for better multi-threading on the client side
- Add option to unset registered callbacks