### PR TITLE
Remove copy_computation_ratio and refactor enum classes

### DIFF
--- a/band/c/c_api.cc
+++ b/band/c/c_api.cc
@@ -66,13 +66,6 @@ void BandAddConfig(BandConfigBuilder* b, int field, int count, ...) {
       int arg = va_arg(vl, int);
       b->impl.AddNumRuns(arg);
     } break;
-    case BAND_PROFILE_COPY_COMPUTATION_RATIO: {
-      std::vector<int> copy_computation_ratio(count);
-      for (int i = 0; i < count; i++) {
-        copy_computation_ratio[i] = va_arg(vl, int);
-      }
-      b->impl.AddCopyComputationRatio(copy_computation_ratio);
-    } break;
     case BAND_PROFILE_SMOOTHING_FACTOR: {
       float arg = va_arg(vl, double);
       b->impl.AddSmoothingFactor(arg);

--- a/band/c/c_api_type.h
+++ b/band/c/c_api_type.h
@@ -11,13 +11,13 @@ extern "C" {
 
 typedef enum BandBackendType {
   kBandTfLite = 0,
-  kBandNumBackendType = 1
+  kBandNumBackendType
 } BandBackendType;
 
 typedef enum BandStatus {
   kBandOk = 0,
-  kBandError = 1,
-  kBandDelegateError = 2
+  kBandError,
+  kBandDelegateError
 } BandStatus;
 
 typedef enum BandWorkerType {
@@ -27,29 +27,29 @@ typedef enum BandWorkerType {
 
 typedef enum BandSchedulerType {
   kBandFixedWorker = 0,
-  kBandRoundRobin = 1,
-  kBandShortestExpectedLatency = 2,
-  kBandFixedWorkerGlobalQueue = 3,
-  kBandHeterogeneousEarliestFinishTime = 4,
-  kBandLeastSlackTimeFirst = 5,
-  kBandHeterogeneousEarliestFinishTimeReserved = 6,
-  kBandNumSchedulerType = 7
+  kBandRoundRobin,
+  kBandShortestExpectedLatency,
+  kBandFixedWorkerGlobalQueue,
+  kBandHeterogeneousEarliestFinishTime,
+  kBandLeastSlackTimeFirst,
+  kBandHeterogeneousEarliestFinishTimeReserved,
+  kBandNumSchedulerType
 } BandSchedulerType;
 
 typedef enum BandCPUMaskFlag {
   kBandAll = 0,
-  kBandLittle = 1,
-  kBandBig = 2,
-  kBandPrimary = 3,
-  kBandNumCpuMask = 4
+  kBandLittle,
+  kBandBig,
+  kBandPrimary,
+  kBandNumCpuMask
 } BandCPUMaskFlag;
 
 typedef enum BandSubgraphPreparationType {
   kBandNoFallbackSubgraph = 0,
-  kBandFallbackPerWorker = 1,
-  kBandUnitSubgraph = 2,
-  kBandMergeUnitSubgraph = 3,
-  kBandNumSubgraphPreparationType = 4,
+  kBandFallbackPerWorker,
+  kBandUnitSubgraph,
+  kBandMergeUnitSubgraph,
+  kBandNumSubgraphPreparationType
 } BandSubgraphPreparationType;
 
 // Single-precision complex data type compatible with the C99 definition.
@@ -65,33 +65,33 @@ typedef struct BandFloat16 {
 // Types supported by tensor
 typedef enum {
   kBandNoType = 0,
-  kBandFloat32 = 1,
-  kBandInt32 = 2,
-  kBandUInt8 = 3,
-  kBandInt64 = 4,
-  kBandString = 5,
-  kBandBool = 6,
-  kBandInt16 = 7,
-  kBandComplex64 = 8,
-  kBandInt8 = 9,
-  kBandFloat16 = 10,
-  kBandFloat64 = 11,
-  kBandNumDataType = 12,
+  kBandFloat32,
+  kBandInt32,
+  kBandUInt8,
+  kBandInt64,
+  kBandString,
+  kBandBool,
+  kBandInt16,
+  kBandComplex64,
+  kBandInt8,
+  kBandFloat16,
+  kBandFloat64,
+  kBandNumDataType,
 } BandDataType;
 
 typedef enum {
   // image format
   kBandGrayScale = 0,
-  kBandRGB = 1,
-  kBandRGBA = 2,
-  kBandYV12 = 3,
-  kBandYV21 = 4,
-  kBandNV21 = 5,
-  kBandNV12 = 6,
+  kBandRGB,
+  kBandRGBA,
+  kBandYV12,
+  kBandYV21,
+  kBandNV21,
+  kBandNV12,
   // raw format, from tensor
   // internal format follows DataType
-  kBandRaw = 7,
-  kBandNumBufferFormat = 8,
+  kBandRaw,
+  kBandNumBufferFormat,
 } BandBufferFormat;
 
 // Buffer content orientation follows EXIF specification. The name of
@@ -100,14 +100,14 @@ typedef enum {
 // details.
 typedef enum {
   kBandTopLeft = 1,
-  kBandTopRight = 2,
-  kBandBottomRight = 3,
-  kBandBottomLeft = 4,
-  kBandLeftTop = 5,
-  kBandRightTop = 6,
-  kBandRightBottom = 7,
-  kBandLeftBottom = 8,
-  kBandNumBufferOrientation = 9,
+  kBandTopRight,
+  kBandBottomRight,
+  kBandBottomLeft,
+  kBandLeftTop,
+  kBandRightTop,
+  kBandRightBottom,
+  kBandLeftBottom,
+  kBandNumBufferOrientation,
 } BandBufferOrientation;
 
 // Supported Quantization Types.
@@ -116,51 +116,50 @@ typedef enum BandQuantizationType {
   kBandNoQuantization = 0,
   // Affine quantization (with support for per-channel quantization).
   // Corresponds to BandAffineQuantization.
-  kBandAffineQuantization = 1,
+  kBandAffineQuantization1,
 } BandQuantizationType;
 
 // TODO #23, #30
 // Add additional devices for HTA, NPU
 typedef enum BandDeviceFlag {
   kBandCPU = 0,
-  kBandGPU = 1,
-  kBandDSP = 2,
-  kBandNPU = 3,
-  kBandNumDeviceFlag = 4,
+  kBandGPU,
+  kBandDSP,
+  kBandNPU,
+  kBandNumDeviceFlag,
 } BandDeviceFlag;
 
 typedef enum BandConfigField {
   BAND_PROFILE_ONLINE = 0,
-  BAND_PROFILE_NUM_WARMUPS = 1,
-  BAND_PROFILE_NUM_RUNS = 2,
-  BAND_PROFILE_COPY_COMPUTATION_RATIO = 3,
-  BAND_PROFILE_SMOOTHING_FACTOR = 4,
-  BAND_PROFILE_DATA_PATH = 5,
-  BAND_PLANNER_SCHEDULE_WINDOW_SIZE = 6,
-  BAND_PLANNER_SCHEDULERS = 7,
-  BAND_PLANNER_CPU_MASK = 8,
-  BAND_PLANNER_LOG_PATH = 9,
-  BAND_WORKER_WORKERS = 10,
-  BAND_WORKER_CPU_MASKS = 11,
-  BAND_WORKER_NUM_THREADS = 12,
-  BAND_WORKER_ALLOW_WORKSTEAL = 13,
-  BAND_WORKER_AVAILABILITY_CHECK_INTERVAL_MS = 14,
-  BAND_MINIMUM_SUBGRAPH_SIZE = 15,
-  BAND_SUBGRAPH_PREPARATION_TYPE = 16,
-  BAND_CPU_MASK = 17,
-  BAND_RESOURCE_MONITOR_DEVICE_PATH = 18,
-  BAND_RESOURCE_MONITOR_INTERVAL_MS = 19,
-  BAND_RESOURCE_MONITOR_LOG_PATH = 20,
+  BAND_PROFILE_NUM_WARMUPS,
+  BAND_PROFILE_NUM_RUNS,
+  BAND_PROFILE_SMOOTHING_FACTOR,
+  BAND_PROFILE_DATA_PATH,
+  BAND_PLANNER_SCHEDULE_WINDOW_SIZE,
+  BAND_PLANNER_SCHEDULERS,
+  BAND_PLANNER_CPU_MASK,
+  BAND_PLANNER_LOG_PATH,
+  BAND_WORKER_WORKERS,
+  BAND_WORKER_CPU_MASKS,
+  BAND_WORKER_NUM_THREADS,
+  BAND_WORKER_ALLOW_WORKSTEAL,
+  BAND_WORKER_AVAILABILITY_CHECK_INTERVAL_MS,
+  BAND_MINIMUM_SUBGRAPH_SIZE,
+  BAND_SUBGRAPH_PREPARATION_TYPE,
+  BAND_CPU_MASK,
+  BAND_RESOURCE_MONITOR_DEVICE_PATH,
+  BAND_RESOURCE_MONITOR_INTERVAL_MS,
+  BAND_RESOURCE_MONITOR_LOG_PATH,
 } BandConfigField;
 
 typedef enum BandImageProcessorBuilderField {
   BAND_CROP = 0,
-  BAND_RESIZE = 1,
-  BAND_ROTATE = 2,
-  BAND_FLIP = 3,
-  BAND_COLOR_SPACE_CONVERT = 4,
-  BAND_NORMALIZE = 5,
-  BAND_DATA_TYPE_CONVERT = 6,
+  BAND_RESIZE,
+  BAND_ROTATE,
+  BAND_FLIP,
+  BAND_COLOR_SPACE_CONVERT,
+  BAND_NORMALIZE,
+  BAND_DATA_TYPE_CONVERT
 } BandImageProcessorBuilderField;
 
 typedef struct BandRequestOption {

--- a/band/common.h
+++ b/band/common.h
@@ -50,41 +50,41 @@ enum class BackendType : size_t {
 
 enum class SchedulerType : size_t {
   kFixedWorker = 0,
-  kRoundRobin = 1,
-  kShortestExpectedLatency = 2,
-  kFixedWorkerGlobalQueue = 3,
-  kHeterogeneousEarliestFinishTime = 4,
-  kLeastSlackTimeFirst = 5,
-  kHeterogeneousEarliestFinishTimeReserved = 6,
+  kRoundRobin,
+  kShortestExpectedLatency,
+  kFixedWorkerGlobalQueue,
+  kHeterogeneousEarliestFinishTime,
+  kLeastSlackTimeFirst,
+  kHeterogeneousEarliestFinishTimeReserved,
 };
 
 enum class CPUMaskFlag : size_t {
   kAll = 0,
-  kLittle = 1,
-  kBig = 2,
-  kPrimary = 3,
+  kLittle,
+  kBig,
+  kPrimary,
 };
 
 enum class SubgraphPreparationType : size_t {
   kNoFallbackSubgraph = 0,
-  kFallbackPerWorker = 1,
-  kUnitSubgraph = 2,
-  kMergeUnitSubgraph = 3,
+  kFallbackPerWorker,
+  kUnitSubgraph,
+  kMergeUnitSubgraph,
 };
 
 enum class DataType : size_t {
   kNoType = 0,
-  kFloat32 = 1,
-  kInt32 = 2,
-  kUInt8 = 3,
-  kInt64 = 4,
-  kString = 5,
-  kBool = 6,
-  kInt16 = 7,
-  kComplex64 = 8,
-  kInt8 = 9,
-  kFloat16 = 10,
-  kFloat64 = 11,
+  kFloat32,
+  kInt32,
+  kUInt8,
+  kInt64,
+  kString,
+  kBool,
+  kInt16,
+  kComplex64,
+  kInt8,
+  kFloat16,
+  kFloat64,
 };
 
 size_t GetDataTypeBytes(DataType type);
@@ -92,15 +92,15 @@ size_t GetDataTypeBytes(DataType type);
 enum class BufferFormat : size_t {
   // image format
   kGrayScale = 0,
-  kRGB = 1,
-  kRGBA = 2,
-  kYV12 = 3,
-  kYV21 = 4,
-  kNV21 = 5,
-  kNV12 = 6,
+  kRGB,
+  kRGBA,
+  kYV12,
+  kYV21,
+  kNV21,
+  kNV12,
   // raw format, from tensor
   // internal format follows DataType
-  kRaw = 7
+  kRaw
 };
 
 // Buffer content orientation follows EXIF specification. The name of
@@ -109,34 +109,34 @@ enum class BufferFormat : size_t {
 // details.
 enum class BufferOrientation : size_t {
   kTopLeft = 1,
-  kTopRight = 2,
-  kBottomRight = 3,
-  kBottomLeft = 4,
-  kLeftTop = 5,
-  kRightTop = 6,
-  kRightBottom = 7,
-  kLeftBottom = 8,
+  kTopRight,
+  kBottomRight,
+  kBottomLeft,
+  kLeftTop,
+  kRightTop,
+  kRightBottom,
+  kLeftBottom,
 };
 
 enum class DeviceFlag : size_t {
   kCPU = 0,
-  kGPU = 1,
-  kDSP = 2,
-  kNPU = 3,
+  kGPU,
+  kDSP,
+  kNPU,
 };
 
 enum class QuantizationType : size_t {
   kNoQuantization = 0,
-  kAffineQuantization = 1,
+  kAffineQuantization,
 };
 
 enum class WorkerType : size_t {
-  kDeviceQueue = 1,
-  kGlobalQueue = 2,
+  kDeviceQueue = 1 << 0,
+  kGlobalQueue = 1 << 1,
 };
 
 enum class JobStatus : size_t {
-  kEnqueueFailed,
+  kEnqueueFailed = 0,
   kQueued,
   kSuccess,
   kSLOViolation,

--- a/band/config.h
+++ b/band/config.h
@@ -11,13 +11,10 @@
 namespace band {
 
 struct ProfileConfig {
-  ProfileConfig() {
-    copy_computation_ratio = std::vector<int>(EnumLength<DeviceFlag>(), 0);
-  }
+  ProfileConfig() {}
   bool online = true;
   int num_warmups = 1;
   int num_runs = 1;
-  std::vector<int> copy_computation_ratio;
   std::string profile_data_path = "";
   float smoothing_factor = 0.1;
 };

--- a/band/config_builder.cc
+++ b/band/config_builder.cc
@@ -150,6 +150,8 @@ absl::StatusOr<RuntimeConfig> RuntimeConfigBuilder::Build() {
   runtime_config.worker_config = worker_config_builder_.Build().value();
   runtime_config.resource_monitor_config =
       resource_monitor_config_builder_.Build().value();
+  runtime_config.subgraph_config = {minimum_subgraph_size_,
+                                    subgraph_preparation_type_};
   return runtime_config;
 }
 }  // namespace band

--- a/band/config_builder.cc
+++ b/band/config_builder.cc
@@ -150,8 +150,6 @@ absl::StatusOr<RuntimeConfig> RuntimeConfigBuilder::Build() {
   runtime_config.worker_config = worker_config_builder_.Build().value();
   runtime_config.resource_monitor_config =
       resource_monitor_config_builder_.Build().value();
-  runtime_config.subgraph_config = {minimum_subgraph_size_,
-                                    subgraph_preparation_type_};
   return runtime_config;
 }
 }  // namespace band

--- a/band/config_builder.cc
+++ b/band/config_builder.cc
@@ -17,11 +17,6 @@ absl::Status ProfileConfigBuilder::IsValid() {
   REPORT_IF_FALSE(ProfileConfigBuilder, num_warmups_ > 0);
   REPORT_IF_FALSE(ProfileConfigBuilder, num_runs_ > 0);
   REPORT_IF_FALSE(ProfileConfigBuilder,
-                  copy_computation_ratio_.size() == EnumLength<DeviceFlag>());
-  for (int i = 0; i < EnumLength<DeviceFlag>(); i++) {
-    REPORT_IF_FALSE(ProfileConfigBuilder, copy_computation_ratio_[i] >= 0);
-  }
-  REPORT_IF_FALSE(ProfileConfigBuilder,
                   smoothing_factor_ >= .0f && smoothing_factor_ <= 1.0f);
   if (online_ == false) {
     REPORT_IF_FALSE(ProfileConfigBuilder, profile_data_path_ != "");
@@ -96,7 +91,6 @@ absl::StatusOr<ProfileConfig> ProfileConfigBuilder::Build() {
   profile_config.online = online_;
   profile_config.num_warmups = num_warmups_;
   profile_config.num_runs = num_runs_;
-  profile_config.copy_computation_ratio = copy_computation_ratio_;
   profile_config.smoothing_factor = smoothing_factor_;
   profile_config.profile_data_path = profile_data_path_;
   return profile_config;

--- a/band/config_builder.h
+++ b/band/config_builder.h
@@ -18,9 +18,7 @@ class ProfileConfigBuilder {
                                       // RuntimeConfigBuilder to access
                                       // variables
  public:
-  ProfileConfigBuilder() {
-    copy_computation_ratio_ = std::vector<int>(EnumLength<DeviceFlag>(), 30000);
-  }
+  ProfileConfigBuilder() {}
   ProfileConfigBuilder& AddOnline(bool online) {
     online_ = online;
     return *this;
@@ -31,11 +29,6 @@ class ProfileConfigBuilder {
   }
   ProfileConfigBuilder& AddNumRuns(int num_runs) {
     num_runs_ = num_runs;
-    return *this;
-  }
-  ProfileConfigBuilder& AddCopyComputationRatio(
-      std::vector<int> copy_computation_ratio) {
-    copy_computation_ratio_ = copy_computation_ratio;
     return *this;
   }
   ProfileConfigBuilder& AddProfileDataPath(std::string profile_data_path) {
@@ -54,7 +47,6 @@ class ProfileConfigBuilder {
   bool online_ = true;
   int num_warmups_ = 1;
   int num_runs_ = 1;
-  std::vector<int> copy_computation_ratio_;
   std::string profile_data_path_ = "";
   float smoothing_factor_ = 0.1;
 };
@@ -192,12 +184,6 @@ class RuntimeConfigBuilder {
     profile_config_builder_.AddNumRuns(num_runs);
     return *this;
   }
-  RuntimeConfigBuilder& AddCopyComputationRatio(
-      std::vector<int> copy_computation_ratio) {
-    profile_config_builder_.AddCopyComputationRatio(copy_computation_ratio);
-    return *this;
-  }
-
   RuntimeConfigBuilder& AddSmoothingFactor(float smoothing_factor) {
     profile_config_builder_.AddSmoothingFactor(smoothing_factor);
     return *this;

--- a/band/docs/benchmark.md
+++ b/band/docs/benchmark.md
@@ -58,7 +58,7 @@ python .\script\run_benchmark.py -c .\benchmark_config.json
   * `PRIMARY`: Primary Core only
 * `num_threads`: Number of computing threads for CPU delegates. [default: -1]
 * `planner_cpu_masks`: CPU cluster mask to set CPU affinity of planner. [default: same value as global `cpu_masks`]
-* `workers`: A vector-like config for per-processor worker. For each worker, specify the following fields. System creates 1 worker per device by default and first provided value overrides the settings (i.e., `cpu_masks`, `num_threads`, `profile_copy_computation_ratio`, ... ) and additional field will add additional worker per device.
+* `workers`: A vector-like config for per-processor worker. For each worker, specify the following fields. System creates 1 worker per device by default and first provided value overrides the settings (i.e., `cpu_masks`, `num_threads`, ... ) and additional field will add additional worker per device.
   * `device`: Target device of specific worker.
     * `CPU`
     * `GPU` 
@@ -72,7 +72,6 @@ python .\script\run_benchmark.py -c .\benchmark_config.json
 * `profile_online`: Online profile or offline profile [default: true]
 * `profile_warmup_runs`: Number of warmup runs before profile. [default: 1]
 * `profile_num_runs`: Number of runs for profile. [default: 1]
-* `profile_copy_computation_ratio`: Ratio of computation / input-ouput copy in `list[int]`. Used for latency estimation for each device type (e.g., CPU, GPU, DSP, NPU). The length of the list should be equal to the 4 (`EnumLength<DeviceFlag>()`). [default: 30000, 30000, 30000, 30000]
 * `schedule_window_size`: The number of planning unit.
 * `workload`: The path to file with workload information. [default: None] 
 
@@ -140,12 +139,6 @@ python .\script\run_benchmark.py -c .\benchmark_config.json
     "profile_online": true,
     "profile_warmup_runs": 3,
     "profile_num_runs": 50,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10
 }

--- a/band/docs/config.md
+++ b/band/docs/config.md
@@ -36,7 +36,6 @@ Each configuration field is optional or required. If a field is optional, then i
 - `online` [type: `bool`, default: `true`]: Profile online if true, offline if false.
 - `num_warmups` [type: `int`, default: `1`]: The number of warmup runs before profile.
 - `num_runs` [type: `int`, default: `1`]: The number of runs for profile
-- `copy_computation_ratio` [type: `std::vector<int>`, default: `[30000, ...]`]: The ratio of computation to input-output copy. Used for latency estimation. The size of the list should be the same as the number of devices.
 - `smoothing_factor` [type: `float`, default: `0.1`]: The momentum to reflect current profiled data. `<updateed_profile> = <smoothing_factor> * <curr_profile> + (1. - <smoothing_factor>) * <prev_profile>`.
 - `profile_data_path` [type: `std::string`, default: `""`]: The input path to the file for offline profile results. If not specified, this will be ignored and will not generate the result file. 
 
@@ -76,7 +75,6 @@ All `Add*` methods are idempotent, i.e. multiple calls behaves the same as a sin
 - `AddOnline(bool online)`
 - `AddNumWarmups(int num_warmups)`
 - `AddNumRuns(int num_runs)`
-- `AddCopyComputationRatio(std::vector<int> copy_computation_ratio)`
 - `AddSmoothingFactor(float smoothing_factor)`
 - `AddProfileLogPath(std::string profile_data_path)`
 - `AddPlannerLogPath(std::string planner_log_path)`

--- a/band/java/src/main/java/org/mrsnu/band/ConfigBuilder.java
+++ b/band/java/src/main/java/org/mrsnu/band/ConfigBuilder.java
@@ -21,10 +21,6 @@ public class ConfigBuilder {
     wrapper.addNumRuns(numRuns);
   }
 
-  public void addCopyComputationRatio(int[] copyComputationRatio) {
-    wrapper.addCopyComputationRatio(copyComputationRatio);
-  }
-
   public void addProfileDataPath(String profileDataPath) {
     wrapper.addProfileDataPath(profileDataPath);
   }

--- a/band/java/src/main/java/org/mrsnu/band/NativeConfigBuilderWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeConfigBuilderWrapper.java
@@ -19,10 +19,6 @@ public class NativeConfigBuilderWrapper implements AutoCloseable {
     addNumRuns(nativeHandle, numRuns);
   }
 
-  public void addCopyComputationRatio(int[] copyComputationRatio) {
-    addCopyComputationRatio(nativeHandle, copyComputationRatio);
-  }
-
   public void addProfileDataPath(String profileDataPath) {
     addProfileDataPath(nativeHandle, profileDataPath);
   }
@@ -133,8 +129,6 @@ public class NativeConfigBuilderWrapper implements AutoCloseable {
   private native void addNumWarmups(long configBuilderHandle, int numWarmups);
 
   private native void addNumRuns(long configBuilderHandle, int numRuns);
-
-  private native void addCopyComputationRatio(long configBuilderHandle, int[] copyComputationRatio);
 
   private native void addProfileDataPath(long configBuilderHandle, String profileDataPath);
 

--- a/band/java/src/main/native/nativeconfigbuilderwrapper_jni.cc
+++ b/band/java/src/main/native/nativeconfigbuilderwrapper_jni.cc
@@ -59,15 +59,6 @@ Java_org_mrsnu_band_NativeConfigBuilderWrapper_addNumRuns(
 }
 
 JNIEXPORT void JNICALL
-Java_org_mrsnu_band_NativeConfigBuilderWrapper_addCopyComputationRatio(
-    JNIEnv* env, jclass clazz, jlong configBuilderHandle,
-    jintArray copyComputationRatio) {
-  ConvertLongToConfigBuilder(env, configBuilderHandle)
-      ->AddCopyComputationRatio(
-          ConvertIntArrayTo<int>(env, copyComputationRatio));
-}
-
-JNIEXPORT void JNICALL
 Java_org_mrsnu_band_NativeConfigBuilderWrapper_addProfileDataPath(
     JNIEnv* env, jclass clazz, jlong configBuilderHandle,
     jstring profileDataPath) {

--- a/band/latency_estimator.cc
+++ b/band/latency_estimator.cc
@@ -24,7 +24,6 @@ absl::Status LatencyEstimator::Init(const ProfileConfig& config) {
   profile_online_ = config.online;
   profile_num_warmups_ = config.num_warmups;
   profile_num_runs_ = config.num_runs;
-  profile_copy_computation_ratio_ = config.copy_computation_ratio;
   profile_smoothing_factor_ = config.smoothing_factor;
 
   return absl::OkStatus();

--- a/band/latency_estimator.h
+++ b/band/latency_estimator.h
@@ -60,7 +60,6 @@ class LatencyEstimator {
   bool profile_online_;
   int profile_num_warmups_;
   int profile_num_runs_;
-  std::vector<int> profile_copy_computation_ratio_;
 
   IEngine* const engine_;
 };

--- a/band/test/config_builder_test.cc
+++ b/band/test/config_builder_test.cc
@@ -69,7 +69,6 @@ TEST(ConfigBuilderTest, RuntimeConfigBuilderTest) {
   auto config = b.AddOnline(true)
                     .AddNumWarmups(1)
                     .AddNumRuns(1)
-                    .AddCopyComputationRatio({1, 2, 3, 4})
                     .AddSmoothingFactor(0.1)
                     .AddProfileDataPath("band/test/data/config.json")
                     .AddMinimumSubgraphSize(5)
@@ -91,10 +90,6 @@ TEST(ConfigBuilderTest, RuntimeConfigBuilderTest) {
   EXPECT_EQ(config_ok.profile_config.online, true);
   EXPECT_EQ(config_ok.profile_config.num_warmups, 1);
   EXPECT_EQ(config_ok.profile_config.num_runs, 1);
-  EXPECT_EQ(config_ok.profile_config.copy_computation_ratio[0], 1);
-  EXPECT_EQ(config_ok.profile_config.copy_computation_ratio[1], 2);
-  EXPECT_EQ(config_ok.profile_config.copy_computation_ratio[2], 3);
-  EXPECT_EQ(config_ok.profile_config.copy_computation_ratio[3], 4);
   EXPECT_EQ(config_ok.profile_config.smoothing_factor, 0.1f);
   EXPECT_EQ(config_ok.profile_config.profile_data_path,
             "band/test/data/config.json");
@@ -122,7 +117,6 @@ TEST(ConfigBuilderTest, DefaultValueTest) {
   EXPECT_EQ(config_ok.profile_config.online, true);
   EXPECT_EQ(config_ok.profile_config.num_warmups, 1);
   EXPECT_EQ(config_ok.profile_config.num_runs, 1);
-  EXPECT_EQ(config_ok.profile_config.copy_computation_ratio[0], 30000);
   EXPECT_EQ(config_ok.profile_config.profile_data_path, "");
   EXPECT_EQ(config_ok.profile_config.smoothing_factor, 0.1f);
   EXPECT_EQ(config_ok.planner_config.log_path, "");

--- a/band/test/data/benchmark_config.json
+++ b/band/test/data/benchmark_config.json
@@ -29,14 +29,12 @@
         {
             "device": "CPU",
             "num_threads": 3,
-            "cpu_masks": "BIG",
-            "profile_copy_computation_ratio": 10
+            "cpu_masks": "BIG"
         },
         {
             "device": "CPU",
             "num_threads": 4,
-            "cpu_masks": "LITTLE",
-            "profile_copy_computation_ratio": 10
+            "cpu_masks": "LITTLE"
         }
     ],
     "running_time_ms": 500,
@@ -45,12 +43,6 @@
     "profile_online": true,
     "profile_warmup_runs": 1,
     "profile_num_runs": 1,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10

--- a/band/test/data/config.json
+++ b/band/test/data/config.json
@@ -13,14 +13,12 @@
         {
             "device": "CPU",
             "num_threads": 3,
-            "cpu_masks": "BIG",
-            "profile_copy_computation_ratio": 10
+            "cpu_masks": "BIG"
         },
         {
             "device": "CPU",
             "num_threads": 4,
-            "cpu_masks": "LITTLE",
-            "profile_copy_computation_ratio": 10
+            "cpu_masks": "LITTLE"
         }
     ],
     "running_time_ms": 60000,
@@ -29,7 +27,6 @@
     "profile_online": true,
     "profile_warmup_runs": 1,
     "profile_num_runs": 1,
-    "profile_copy_computation_ratio": 1000,
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10

--- a/band/tool/benchmark.cc
+++ b/band/tool/benchmark.cc
@@ -177,13 +177,6 @@ bool tool::Benchmark::LoadRuntimeConfigs(const Json::Value& root) {
     if (root["profile_num_runs"].isInt()) {
       builder.AddNumRuns(root["profile_num_runs"].asInt());
     }
-    if (root["profile_copy_computation_ratio"].isNumeric()) {
-      std::vector<int> copy_computation_ratio;
-      for (auto ratio : root["profile_copy_computation_ratio"]) {
-        copy_computation_ratio.push_back(ratio.asInt());
-      }
-      builder.AddCopyComputationRatio(copy_computation_ratio);
-    }
     if (root["profile_smoothing_factor"].isNumeric()) {
       builder.AddSmoothingFactor(root["profile_smoothing_factor"].asFloat());
     }

--- a/script/config_samples/benchmark_heft.json
+++ b/script/config_samples/benchmark_heft.json
@@ -54,13 +54,6 @@
     "profile_online": true,
     "profile_warmup_runs": 3,
     "profile_num_runs": 50,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10

--- a/script/config_samples/benchmark_lsf.json
+++ b/script/config_samples/benchmark_lsf.json
@@ -54,13 +54,6 @@
     "profile_online": true,
     "profile_warmup_runs": 3,
     "profile_num_runs": 50,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10

--- a/script/config_samples/benchmark_rr.json
+++ b/script/config_samples/benchmark_rr.json
@@ -54,13 +54,6 @@
     "profile_online": true,
     "profile_warmup_runs": 3,
     "profile_num_runs": 50,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10

--- a/script/config_samples/benchmark_sel.json
+++ b/script/config_samples/benchmark_sel.json
@@ -49,13 +49,6 @@
     "profile_online": true,
     "profile_warmup_runs": 3,
     "profile_num_runs": 50,
-    "profile_copy_computation_ratio": [
-        1000,
-        1000,
-        1000,
-        1000,
-        1000
-    ],
     "allow_work_steal": true,
     "availability_check_interval_ms": 30000,
     "schedule_window_size": 10


### PR DESCRIPTION
# List of changes
1. Remove `copy_computation_ratio` since it is not utilized by anyone.
2. No explicit integer is specified to enum classes as deletion and addition can cause a human error, except for the first element.