### PR TITLE
Memory leak fix for buffer

### DIFF
--- a/band/buffer/common_operator.cc
+++ b/band/buffer/common_operator.cc
@@ -33,8 +33,8 @@ void NormalizeFromTo(const Buffer& input, Buffer* output, float mean,
     output_data[i] = static_cast<OutputType>((input_data[i] - mean)) / std;
   }
   BAND_LOG(LogSeverity::kInternal, "Normalize: %s %s %f %f",
-                ToString(input.GetDataType()), ToString(output->GetDataType()),
-                mean, std);
+           ToString(input.GetDataType()), ToString(output->GetDataType()), mean,
+           std);
 }
 
 template <typename InputType>
@@ -57,7 +57,7 @@ void NormalizeFrom(const Buffer& input, Buffer* output, float mean, float std) {
       break;
     default:
       BAND_LOG(LogSeverity::kError, "Normalize: unsupported data type %s",
-                    ToString(output->GetDataType()));
+               ToString(output->GetDataType()));
       break;
   }
 }
@@ -68,9 +68,8 @@ IBufferOperator::Type Normalize::GetOpType() const { return Type::kCommon; }
 
 void Normalize::SetOutput(Buffer* output) {
   if (inplace_) {
-    BAND_LOG(
-        LogSeverity::kError,
-        "Normalize: setting output buffer is not allowed for inplace");
+    BAND_LOG(LogSeverity::kError,
+             "Normalize: setting output buffer is not allowed for inplace");
   } else {
     IBufferOperator::SetOutput(output);
   }
@@ -151,9 +150,11 @@ absl::Status Normalize::ValidateOutput(const Buffer& input) const {
 
 absl::Status Normalize::CreateOutput(const Buffer& input) {
   if (!inplace_) {
-    output_ = Buffer::CreateEmpty(
-        input.GetDimension()[0], input.GetDimension()[1],
-        input.GetBufferFormat(), input.GetDataType(), input.GetOrientation());
+    output_ = std::unique_ptr<Buffer, void (*)(Buffer*)>(
+        Buffer::CreateEmpty(input.GetDimension()[0], input.GetDimension()[1],
+                            input.GetBufferFormat(), input.GetDataType(),
+                            input.GetOrientation()),
+        [](Buffer* buffer) { delete buffer; });
   }
 
   return absl::Status();

--- a/band/buffer/image_operator.h
+++ b/band/buffer/image_operator.h
@@ -137,7 +137,7 @@ class AutoConvert : public IBufferOperator {
   AutoConvert() = default;
   AutoConvert(const AutoConvert& rhs);
   AutoConvert& operator=(const AutoConvert& rhs);
-  virtual ~AutoConvert() override;
+  virtual ~AutoConvert();
 
   virtual Type GetOpType() const override;
   virtual absl::Status ProcessImpl(const Buffer& input) override;

--- a/band/buffer/image_operator.h
+++ b/band/buffer/image_operator.h
@@ -134,7 +134,11 @@ class ColorSpaceConvert : public IBufferOperator {
 // target dimension from bottom to top.
 class AutoConvert : public IBufferOperator {
  public:
+  AutoConvert() = default;
+  AutoConvert(const AutoConvert& rhs);
+  AutoConvert& operator=(const AutoConvert& rhs);
   virtual ~AutoConvert() override;
+
   virtual Type GetOpType() const override;
   virtual absl::Status ProcessImpl(const Buffer& input) override;
   virtual absl::Status ValidateInput(const Buffer& input) const override;
@@ -149,9 +153,9 @@ class AutoConvert : public IBufferOperator {
   bool RequiresResize(const Buffer& input) const;
   bool RequiresDataTypeConvert(const Buffer& input) const;
 
-  ColorSpaceConvert color_space_convert_;
-  Resize resize_;
-  DataTypeConvert data_type_convert_;
+  std::unique_ptr<ColorSpaceConvert> color_space_convert_ = nullptr;
+  std::unique_ptr<Resize> resize_ = nullptr;
+  std::unique_ptr<DataTypeConvert> data_type_convert_ = nullptr;
 };
 
 }  // namespace buffer

--- a/band/buffer/operator.h
+++ b/band/buffer/operator.h
@@ -30,8 +30,13 @@ namespace band {
 // for future use (e.g. for the next operator with the same input format).
 class IBufferOperator {
  public:
-  IBufferOperator() = default;
-  virtual ~IBufferOperator();
+  IBufferOperator() : output_(nullptr, [](Buffer*) {}) {}
+  virtual ~IBufferOperator() = default;
+
+  IBufferOperator(IBufferOperator&&);
+  IBufferOperator(const IBufferOperator& rhs);
+  IBufferOperator& operator=(const IBufferOperator&);
+
   absl::Status Process(const Buffer& input);
   virtual void SetOutput(Buffer* output);
   Buffer* GetOutput();
@@ -59,8 +64,6 @@ class IBufferOperator {
 
  protected:
   friend class ImageProcessorBuilder;
-  IBufferOperator(const IBufferOperator&) = default;
-  IBufferOperator& operator=(const IBufferOperator&) = default;
   // Process the input buffer and generate the output buffer.
   // Returns following status:
   // - OK: the operation is successful.
@@ -70,7 +73,8 @@ class IBufferOperator {
   virtual IBufferOperator* Clone() const = 0;
 
   bool output_assigned_ = false;
-  Buffer* output_ = nullptr;
+  std::unique_ptr<Buffer, void (*)(Buffer*)> output_ =
+      std::unique_ptr<Buffer, void (*)(Buffer*)>(nullptr, [](Buffer*) {});
 };
 }  // namespace band
 

--- a/band/java/src/main/java/org/mrsnu/band/Buffer.java
+++ b/band/java/src/main/java/org/mrsnu/band/Buffer.java
@@ -19,12 +19,17 @@ package org.mrsnu.band;
 import android.media.Image.Plane;
 import java.nio.ByteBuffer;
 
-public class Buffer {
+public class Buffer implements AutoCloseable {
   private NativeBufferWrapper wrapper;
 
   public Buffer(final Tensor tensor) {
     wrapper = new NativeBufferWrapper();
     wrapper.setFromTensor(tensor);
+  }
+
+  @Override
+  public void close() {
+    wrapper = null;
   }
 
   public Buffer(final ByteBuffer buffer, int width, int height, BufferFormat bufferFormat) {

--- a/band/java/src/main/java/org/mrsnu/band/Buffer.java
+++ b/band/java/src/main/java/org/mrsnu/band/Buffer.java
@@ -19,6 +19,9 @@ package org.mrsnu.band;
 import android.media.Image.Plane;
 import java.nio.ByteBuffer;
 
+// Caution: This class has a native resource.
+// You may need to use `try-with-resources` statement to
+// avoid potential memory leak.
 public class Buffer implements AutoCloseable {
   private NativeBufferWrapper wrapper;
 

--- a/band/java/src/main/java/org/mrsnu/band/ImageProcessor.java
+++ b/band/java/src/main/java/org/mrsnu/band/ImageProcessor.java
@@ -16,6 +16,9 @@
 
 package org.mrsnu.band;
 
+// Caution: This class has a native resource.
+// You may need to use `try-with-resources` statement to
+// avoid potential memory leak.
 public class ImageProcessor implements AutoCloseable {
   private long nativeHandle = 0;
 
@@ -37,7 +40,7 @@ public class ImageProcessor implements AutoCloseable {
   }
 
   private native void process(
-    long imageProcessorHandle, Object srcBufferObject, Object dstTensorObject);
+      long imageProcessorHandle, Object srcBufferObject, Object dstTensorObject);
 
   private native void deleteImageProcessor(long imageProcessorHandle);
 }

--- a/band/java/src/main/java/org/mrsnu/band/ImageProcessorBuilder.java
+++ b/band/java/src/main/java/org/mrsnu/band/ImageProcessorBuilder.java
@@ -16,12 +16,17 @@
 
 package org.mrsnu.band;
 
-public class ImageProcessorBuilder {
+public class ImageProcessorBuilder implements AutoCloseable {
   private NativeImageProcessorBuilderWrapper wrapper;
 
   public ImageProcessorBuilder() {
     Band.init();
     wrapper = new NativeImageProcessorBuilderWrapper();
+  }
+
+  @Override
+  public void close() {
+    wrapper = null;
   }
 
   public ImageProcessorBuilder addCrop(int x0, int y0, int x1, int y1) {

--- a/band/java/src/main/java/org/mrsnu/band/NativeBufferWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeBufferWrapper.java
@@ -17,6 +17,7 @@
 package org.mrsnu.band;
 
 import android.media.Image.Plane;
+import android.util.Log;
 import java.nio.ByteBuffer;
 
 class NativeBufferWrapper implements AutoCloseable {

--- a/band/java/src/main/java/org/mrsnu/band/NativeBufferWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeBufferWrapper.java
@@ -17,7 +17,6 @@
 package org.mrsnu.band;
 
 import android.media.Image.Plane;
-import android.util.Log;
 import java.nio.ByteBuffer;
 
 class NativeBufferWrapper implements AutoCloseable {

--- a/band/java/src/main/java/org/mrsnu/band/NativeImageProcessorBuilderWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeImageProcessorBuilderWrapper.java
@@ -16,7 +16,6 @@
 
 package org.mrsnu.band;
 
-import android.util.Log;
 import java.nio.ByteBuffer;
 
 class NativeImageProcessorBuilderWrapper implements AutoCloseable {
@@ -24,12 +23,10 @@ class NativeImageProcessorBuilderWrapper implements AutoCloseable {
 
   NativeImageProcessorBuilderWrapper() {
     nativeHandle = createImageProcessorBuilder();
-    Log.d("NativeImageProcessorBuilderWrapper", "NIPBW created " + nativeHandle);
   }
 
   @Override
   public void close() {
-    Log.d("NativeImageProcessorBuilderWrapper", "NIPBW closed " + nativeHandle);
     deleteImageProcessorBuilder(nativeHandle);
     nativeHandle = 0;
   }

--- a/band/java/src/main/java/org/mrsnu/band/NativeImageProcessorBuilderWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeImageProcessorBuilderWrapper.java
@@ -16,6 +16,7 @@
 
 package org.mrsnu.band;
 
+import android.util.Log;
 import java.nio.ByteBuffer;
 
 class NativeImageProcessorBuilderWrapper implements AutoCloseable {
@@ -23,6 +24,14 @@ class NativeImageProcessorBuilderWrapper implements AutoCloseable {
 
   NativeImageProcessorBuilderWrapper() {
     nativeHandle = createImageProcessorBuilder();
+    Log.d("NativeImageProcessorBuilderWrapper", "NIPBW created " + nativeHandle);
+  }
+
+  @Override
+  public void close() {
+    Log.d("NativeImageProcessorBuilderWrapper", "NIPBW closed " + nativeHandle);
+    deleteImageProcessorBuilder(nativeHandle);
+    nativeHandle = 0;
   }
 
   public void addCrop(int x0, int y0, int x1, int y1) {
@@ -57,18 +66,11 @@ class NativeImageProcessorBuilderWrapper implements AutoCloseable {
     return (ImageProcessor) build(nativeHandle);
   }
 
-  @Override
-  public void close() {
-    deleteImageProcessorBuilder(nativeHandle);
-    nativeHandle = 0;
-  }
-
   private native long createImageProcessorBuilder();
 
   private native void deleteImageProcessorBuilder(long imageProcessorBuilderHandle);
 
-  private native void addCrop(
-      long imageProcessorBuilderHandle, int x0, int y0, int x1, int y1);
+  private native void addCrop(long imageProcessorBuilderHandle, int x0, int y0, int x1, int y1);
 
   private native void addResize(long imageProcessorBuilderHandle, int width, int height);
 

--- a/band/java/src/main/java/org/mrsnu/band/NativeModelWrapper.java
+++ b/band/java/src/main/java/org/mrsnu/band/NativeModelWrapper.java
@@ -31,7 +31,6 @@ class NativeModelWrapper implements AutoCloseable {
   @Override
   public void close() {
     deleteModel(nativeHandle);
-    nativeHandle = 0;
   }
 
   public void loadFromFile(BackendType backendType, String filePath) {
@@ -62,7 +61,8 @@ class NativeModelWrapper implements AutoCloseable {
 
   private static native void loadFromFile(long modelHandle, int backendType, String filePath);
 
-  private static native void loadFromBuffer(long modelHandle, int backendType, ByteBuffer modelBuffer);
+  private static native void loadFromBuffer(
+      long modelHandle, int backendType, ByteBuffer modelBuffer);
 
   private static native int[] getSupportedBackends(long modelHandle);
 }

--- a/band/java/src/main/java/org/mrsnu/band/Tensor.java
+++ b/band/java/src/main/java/org/mrsnu/band/Tensor.java
@@ -19,6 +19,9 @@ package org.mrsnu.band;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+// Caution: This class has a native resource.
+// You may need to use `try-with-resources` statement to
+// avoid potential memory leak.
 public class Tensor implements AutoCloseable {
   private NativeTensorWrapper wrapper;
 

--- a/band/java/src/main/java/org/mrsnu/band/Tensor.java
+++ b/band/java/src/main/java/org/mrsnu/band/Tensor.java
@@ -16,17 +16,22 @@
 
 package org.mrsnu.band;
 
-import java.util.List;
 import java.nio.ByteBuffer;
+import java.util.List;
 
-public class Tensor {
+public class Tensor implements AutoCloseable {
   private NativeTensorWrapper wrapper;
 
   Tensor(long nativeHandle) {
     Band.init();
     wrapper = new NativeTensorWrapper(nativeHandle);
   }
-  
+
+  @Override
+  public void close() {
+    wrapper = null;
+  }
+
   public DataType getType() {
     return wrapper.getType();
   }

--- a/band/java/src/main/native/BUILD
+++ b/band/java/src/main/native/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//band:band.bzl", "band_copts", "band_cc_library")
+load("//band:band.bzl", "band_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -60,5 +60,5 @@ exports_files(
     [
         "exported_symbols.lds",
         "version_scripts.lds",
-    ]
+    ],
 )


### PR DESCRIPTION
### List of changes
- Enforce strict ownership with unique_ptr for dynamic resources within operators.
- Change Java classes with native resources (e.g., `Buffer` or `Tensor` ...) so that users can deallocate on their own w/o relying on GC.